### PR TITLE
feat: Implement dark mode, categories screen, and fix profile error

### DIFF
--- a/Handlr/app/(tabs)/_layout.tsx
+++ b/Handlr/app/(tabs)/_layout.tsx
@@ -1,32 +1,34 @@
 import React from 'react';
-import { Tabs } from 'expo-router';
-import { Home, Search, PlusCircle, MessageSquare, User } from 'lucide-react-native';
+import { Tabs, router } from 'expo-router'; // Added router for custom create button
+import { Home, Search, PlusCircle, MessageSquare, User, LayoutGrid } from 'lucide-react-native'; // Added LayoutGrid
 import { Platform, View } from 'react-native';
-import theme from '@/constants/theme';
+import originalTheme from '@/constants/theme'; // Renamed theme to originalTheme
+import { useTheme } from '../../context/ThemeContext'; // Added useTheme
 
 export default function TabLayout() {
-  // Calculate tab bar height based on platform
+  const { colors } = useTheme(); // Accessed theme colors
+
   const tabBarHeight = Platform.OS === 'ios' ? 88 : 60;
   const tabBarPaddingBottom = Platform.OS === 'ios' ? 28 : 8;
 
   return (
     <Tabs
       screenOptions={{
-        tabBarActiveTintColor: theme.colors.light.primary,
-        tabBarInactiveTintColor: theme.colors.light.inactive,
+        tabBarActiveTintColor: colors.primary, 
+        tabBarInactiveTintColor: colors.subtext, 
         tabBarStyle: {
-          borderTopColor: theme.colors.light.border,
+          borderTopColor: colors.border, 
           height: tabBarHeight,
           paddingBottom: tabBarPaddingBottom,
           paddingTop: 8,
         },
         headerShown: false,
-        tabBarBackground: () => (
+        tabBarBackground: () => ( 
           <View 
             style={{ 
-              backgroundColor: theme.colors.light.background,
+              backgroundColor: colors.card, 
               borderTopWidth: 1,
-              borderTopColor: theme.colors.light.border,
+              borderTopColor: colors.border,
               height: '100%',
             }} 
           />
@@ -34,47 +36,72 @@ export default function TabLayout() {
       }}
     >
       <Tabs.Screen
-        name="index"
+        name="index" // Home
         options={{
           title: 'Home',
-          tabBarIcon: ({ color, size }) => <Home size={size} color={color} />,
+          tabBarIcon: ({ color, focused }) => <Home size={focused ? 26 : 24} color={color} strokeWidth={focused ? 2.5 : 2} />,
+        }}
+      />
+      <Tabs.Screen
+        name="categories" // New Categories Tab
+        options={{
+          title: 'Categories',
+          tabBarIcon: ({ color, focused }) => (
+            <LayoutGrid size={focused ? 26 : 24} color={color} strokeWidth={focused ? 2.5 : 2} />
+          ),
         }}
       />
       <Tabs.Screen
         name="explore"
         options={{
           title: 'Explore',
-          tabBarIcon: ({ color, size }) => <Search size={size} color={color} />,
+          tabBarIcon: ({ color, focused }) => <Search size={focused ? 26 : 24} color={color} strokeWidth={focused ? 2.5 : 2} />,
         }}
       />
       <Tabs.Screen
-        name="create"
+        name="create" // Placeholder name for the tab item itself
         options={{
-          title: 'Create',
-          tabBarIcon: ({ color, size }) => <PlusCircle size={size} color={color} />,
-          tabBarButton: (props) => (
-            <Tabs.Screen
-              name="task/create"
-              options={{
-                title: 'Create Task',
-                tabBarIcon: ({ color, size }) => <PlusCircle size={size} color={color} />,
-              }}
-            />
+          title: 'Create', // This title won't be visible due to tabBarLabel: () => null
+          tabBarIcon: ({ focused }) => ( 
+            <View style={{
+              backgroundColor: colors.primary,
+              padding: originalTheme.spacing.s,
+              borderRadius: originalTheme.radius.xl, 
+              width: 50,
+              height: 50,
+              justifyContent: 'center',
+              alignItems: 'center',
+              transform: [{ translateY: Platform.OS === 'ios' ? -15 : -10 }], 
+              shadowColor: colors.black, 
+              shadowOffset: { width: 0, height: 3 },
+              shadowOpacity: 0.2,
+              shadowRadius: 4,
+              elevation: 5,
+            }}>
+              <PlusCircle size={28} color={originalTheme.colors.common.white} />
+            </View>
           ),
+          tabBarLabel: () => null, 
+        }}
+        listeners={{
+          tabPress: (e) => {
+            e.preventDefault(); 
+            router.push('/task/create'); 
+          },
         }}
       />
       <Tabs.Screen
         name="chats"
         options={{
           title: 'Chats',
-          tabBarIcon: ({ color, size }) => <MessageSquare size={size} color={color} />,
+          tabBarIcon: ({ color, focused }) => <MessageSquare size={focused ? 26 : 24} color={color} strokeWidth={focused ? 2.5 : 2} />,
         }}
       />
       <Tabs.Screen
         name="profile"
         options={{
           title: 'Profile',
-          tabBarIcon: ({ color, size }) => <User size={size} color={color} />,
+          tabBarIcon: ({ color, focused }) => <User size={focused ? 26 : 24} color={color} strokeWidth={focused ? 2.5 : 2} />,
         }}
       />
     </Tabs>

--- a/Handlr/app/(tabs)/categories.tsx
+++ b/Handlr/app/(tabs)/categories.tsx
@@ -1,0 +1,185 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, FlatList } from 'react-native'; // Added FlatList
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useTheme } from '../../context/ThemeContext';
+import originalTheme from '@/constants/theme'; 
+import SearchInput from '../../../components/SearchInput';
+import { 
+  CaretDown,
+  House, 
+  Droplets, 
+  Nut, // Using Nut for Electrician and Carpentry as a general "fixing" icon
+  Package as MovingIcon, // Renamed to avoid conflict with React.Package
+  Car, 
+  PaintBrush, 
+  Leaf, 
+  Dog, 
+  Laptop, 
+  CookingPot, 
+  Scissors, 
+  Baby 
+} from 'lucide-react-native';
+import { categories as mockCategories } from '../../../mocks/categories'; // Import mock categories
+
+type AppColorsType = ReturnType<typeof useTheme>['colors'];
+type CategoryType = typeof mockCategories[0]; // Infer type from mock data
+
+// Icon mapping using string keys (category IDs from mock data)
+const iconMap: { [key: string]: React.ElementType } = {
+  '1': House,        // Cleaning (Spray can in mock, using House as generic home service)
+  '2': Droplets,     // Plumbing (Wrench in mock)
+  '3': Nut,          // Electrician (Zap in mock)
+  '4': Nut,          // Carpentry (Hammer in mock)
+  '5': PaintBrush,   // Painting
+  '6': Leaf,         // Gardening (Flower in mock)
+  '7': MovingIcon,   // Errands (Shopping bag in mock, Package for delivery/errands)
+  '8': MovingIcon,   // Moving (Truck in mock, Package can also represent moving boxes)
+  // Add more based on your actual mockCategories IDs and desired icons
+  // Default can be set in CategoryGridItem
+};
+
+interface CategoryGridItemProps {
+  item: CategoryType;
+  onPress: () => void;
+  colors: AppColorsType;
+  itemStyle: {
+    card: any; // Consider more specific style types if needed
+    text: any;
+  };
+}
+
+const CategoryGridItem: React.FC<CategoryGridItemProps> = ({ item, onPress, colors, itemStyle }) => {
+  const IconComponent = iconMap[String(item.id)] || House; // Default to House icon
+  return (
+    <TouchableOpacity onPress={onPress} style={itemStyle.card}>
+      <IconComponent size={24} color={colors.text} />
+      <Text style={itemStyle.text} numberOfLines={2}>{item.name}</Text>
+    </TouchableOpacity>
+  );
+};
+
+export default function CategoriesScreen() {
+  const { colors } = useTheme();
+  const styles = dynamicStyles(colors, originalTheme);
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // TODO: Implement Filter Logic
+  // TODO: Implement actual navigation for category press
+
+  return (
+    <>
+      <SafeAreaView style={styles.container} edges={['top', 'bottom']}>
+        <ScrollView showsVerticalScrollIndicator={false}>
+          <View style={styles.searchContainer}>
+            <SearchInput
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              placeholder="Search categories or services"
+            />
+          </View>
+
+          <View style={styles.filtersContainer}>
+            <TouchableOpacity style={styles.filterButton}>
+              <Text style={styles.filterButtonText}>Popular</Text>
+              <CaretDown size={18} color={colors.text} />
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.filterButton}>
+              <Text style={styles.filterButtonText}>Nearby</Text>
+              <CaretDown size={18} color={colors.text} />
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.filterButton}>
+              <Text style={styles.filterButtonText}>Price</Text>
+              <CaretDown size={18} color={colors.text} />
+            </TouchableOpacity>
+          </View>
+          
+          <Text style={styles.sectionTitleText}>All Categories</Text>
+          <FlatList
+            data={mockCategories}
+            renderItem={({ item }) => (
+              <CategoryGridItem 
+                item={item} 
+                onPress={() => console.log('Pressed Category:', item.name, item.id)} 
+                colors={colors} 
+                itemStyle={{ card: styles.categoryGridItemCard, text: styles.categoryGridItemText }}
+              />
+            )}
+            keyExtractor={(item) => String(item.id)}
+            numColumns={2}
+            columnWrapperStyle={styles.gridRow}
+            contentContainerStyle={styles.gridContentContainer}
+            showsVerticalScrollIndicator={false}
+            scrollEnabled={false} // Disable FlatList scrolling, rely on parent ScrollView
+          />
+        </ScrollView>
+      </SafeAreaView>
+    </>
+  );
+}
+
+const dynamicStyles = (colors: AppColorsType, currentTheme: typeof originalTheme) => 
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    searchContainer: {
+      paddingHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.m,
+      paddingTop: currentTheme.spacing.l, 
+    },
+    filtersContainer: {
+      flexDirection: 'row',
+      paddingHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.l,
+      gap: currentTheme.spacing.s, 
+    },
+    filterButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.card, 
+      paddingVertical: currentTheme.spacing.s,
+      paddingHorizontal: currentTheme.spacing.m,
+      borderRadius: 20, 
+    },
+    filterButtonText: {
+      ...currentTheme.typography.bodySmall, 
+      color: colors.text,
+      marginRight: currentTheme.spacing.xs,
+    },
+    sectionTitleText: { // New style for section title
+      ...currentTheme.typography.h3, 
+      color: colors.text,
+      paddingHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.m,
+      marginTop: currentTheme.spacing.l, // Added margin top
+    },
+    gridContentContainer: { // Style for FlatList content
+      // paddingHorizontal: currentTheme.spacing.l, // Horizontal padding handled by parent ScrollView or this
+      paddingBottom: currentTheme.spacing.l,
+    },
+    gridRow: { // Style for FlatList columnWrapperStyle
+      justifyContent: 'space-between',
+      gap: currentTheme.spacing.m, 
+      marginBottom: currentTheme.spacing.m,
+      paddingHorizontal: currentTheme.spacing.l, // Add horizontal padding to the row itself
+    },
+    categoryGridItemCard: {
+      flex: 1, // Essential for numColumns
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.card,
+      padding: currentTheme.spacing.m,
+      borderRadius: currentTheme.radius.m,
+      borderWidth: 1,
+      borderColor: colors.border,
+      gap: currentTheme.spacing.m, // Space between icon and text
+    },
+    categoryGridItemText: {
+      ...currentTheme.typography.body, // Or bodySmall if preferred
+      fontWeight: '600',
+      color: colors.text,
+      flexShrink: 1, // Allow text to wrap and shrink if icon takes space
+    },
+    // placeholderText style removed as placeholder View is removed
+  });

--- a/Handlr/app/(tabs)/index.tsx
+++ b/Handlr/app/(tabs)/index.tsx
@@ -1,13 +1,13 @@
-
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, FlatList, TouchableOpacity, Image, Modal } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Bell, MapPin, X } from 'lucide-react-native';
-import theme from '@/constants/theme';
+import originalTheme from '@/constants/theme'; // Renamed
+import { useTheme } from '../../context/ThemeContext'; // Added
 import { categories } from '@/mocks/categories';
 import { taskers } from '@/mocks/taskers';
-import { tasks } from '@/mocks/tasks';
+import { tasks } from '@/mocks/tasks'; 
 import { Category, Tasker, Task } from '@/types';
 import CategoryCard from '@/components/CategoryCard';
 import TaskerCard from '@/components/TaskerCard';
@@ -16,6 +16,9 @@ import SearchInput from '@/components/SearchInput';
 import { useAuthStore } from '@/store/authStore';
 
 export default function HomeScreen() {
+  const { colors } = useTheme(); 
+  const styles = dynamicStyles(colors, originalTheme); 
+
   const [searchQuery, setSearchQuery] = useState('');
   const [showNotifications, setShowNotifications] = useState(false);
   const user = useAuthStore(state => state.user);
@@ -35,29 +38,10 @@ export default function HomeScreen() {
     router.push(`/task/${task.id}`);
   };
 
-  // Mock notifications
-  const notifications = [
-    {
-      id: '1',
-      title: 'New message',
-      message: 'Rajesh Kumar sent you a message',
-      time: '10 min ago',
-      read: false,
-    },
-    {
-      id: '2',
-      title: 'Task update',
-      message: 'Your cleaning task has been accepted',
-      time: '1 hour ago',
-      read: true,
-    },
-    {
-      id: '3',
-      title: 'Payment successful',
-      message: 'Payment for plumbing task was successful',
-      time: '2 days ago',
-      read: true,
-    },
+  const currentNotificationsData = [ // Renamed mock data
+    { id: '1', title: 'New message', message: 'Rajesh Kumar sent you a message', time: '10 min ago', read: false, },
+    { id: '2', title: 'Task update', message: 'Your cleaning task has been accepted', time: '1 hour ago', read: true, },
+    { id: '3', title: 'Payment successful', message: 'Payment for plumbing task was successful', time: '2 days ago', read: true, },
   ];
 
   return (
@@ -67,16 +51,16 @@ export default function HomeScreen() {
           <View>
             <Text style={styles.greeting}>Hello, {user?.name || 'User'}</Text>
             <View style={styles.locationContainer}>
-              <MapPin size={14} color={theme.colors.light.subtext} />
-              <Text style={styles.location}>Bangalore, India</Text>
+              <MapPin size={14} color={colors.subtext} /> 
+              <Text style={styles.locationText}>Bangalore, India</Text>
             </View>
           </View>
           <TouchableOpacity 
             style={styles.notificationButton}
             onPress={() => setShowNotifications(true)}
           >
-            <Bell size={24} color={theme.colors.light.text} />
-            <View style={styles.notificationBadge} />
+            <Bell size={24} color={colors.text} /> 
+            {currentNotificationsData.some(n => !n.read) && <View style={styles.notificationBadge} />}
           </TouchableOpacity>
         </View>
 
@@ -118,7 +102,7 @@ export default function HomeScreen() {
             </TouchableOpacity>
           </View>
           <FlatList
-            data={taskers.slice(0, 3)}
+            data={taskers.slice(0, 3)} 
             horizontal
             showsHorizontalScrollIndicator={false}
             keyExtractor={(item) => item.id}
@@ -138,7 +122,7 @@ export default function HomeScreen() {
               <Text style={styles.seeAllText}>Create New</Text>
             </TouchableOpacity>
           </View>
-          {tasks.length > 0 ? (
+          {tasks.length > 0 ? ( 
             tasks.map((task) => (
               <TaskCard key={task.id} task={task as Task} onPress={handleTaskPress} />
             ))
@@ -163,7 +147,6 @@ export default function HomeScreen() {
         </View>
       </ScrollView>
 
-      {/* Notifications Modal */}
       <Modal
         visible={showNotifications}
         animationType="slide"
@@ -171,16 +154,16 @@ export default function HomeScreen() {
         onRequestClose={() => setShowNotifications(false)}
       >
         <View style={styles.modalOverlay}>
-          <View style={styles.notificationsContainer}>
+          <View style={styles.notificationsModalContainer}>
             <View style={styles.notificationsHeader}>
               <Text style={styles.notificationsTitle}>Notifications</Text>
               <TouchableOpacity onPress={() => setShowNotifications(false)}>
-                <X size={24} color={theme.colors.light.text} />
+                <X size={24} color={colors.text} /> 
               </TouchableOpacity>
             </View>
             
             <FlatList
-              data={notifications}
+              data={currentNotificationsData}
               keyExtractor={(item) => item.id}
               renderItem={({ item }) => (
                 <TouchableOpacity 
@@ -210,179 +193,187 @@ export default function HomeScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: theme.colors.light.background,
-  },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: theme.spacing.l,
-    paddingTop: theme.spacing.l,
-    paddingBottom: theme.spacing.m,
-  },
-  greeting: {
-    ...theme.typography.h2,
-    marginBottom: theme.spacing.xs,
-  },
-  locationContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  location: {
-    ...theme.typography.bodySmall,
-    color: theme.colors.light.subtext,
-    marginLeft: theme.spacing.xs,
-  },
-  notificationButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    backgroundColor: theme.colors.light.card,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  notificationBadge: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: theme.colors.light.error,
-  },
-  searchContainer: {
-    paddingHorizontal: theme.spacing.l,
-    marginBottom: theme.spacing.l,
-  },
-  categoriesSection: {
-    marginBottom: theme.spacing.l,
-  },
-  sectionHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: theme.spacing.l,
-    marginBottom: theme.spacing.m,
-  },
-  sectionTitle: {
-    ...theme.typography.h3,
-  },
-  seeAllText: {
-    ...theme.typography.bodySmall,
-    color: theme.colors.light.primary,
-    fontWeight: '600',
-  },
-  categoriesList: {
-    paddingHorizontal: theme.spacing.l,
-  },
-  section: {
-    marginBottom: theme.spacing.xl,
-  },
-  taskersList: {
-    paddingHorizontal: theme.spacing.l,
-  },
-  taskerCardContainer: {
-    width: 280,
-    marginRight: theme.spacing.m,
-  },
-  emptyTasksContainer: {
-    alignItems: 'center',
-    padding: theme.spacing.xl,
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    marginHorizontal: theme.spacing.l,
-  },
-  emptyTasksImage: {
-    width: 120,
-    height: 120,
-    marginBottom: theme.spacing.l,
-  },
-  emptyTasksTitle: {
-    ...theme.typography.h3,
-    marginBottom: theme.spacing.s,
-  },
-  emptyTasksText: {
-    ...theme.typography.body,
-    color: theme.colors.light.subtext,
-    textAlign: 'center',
-    marginBottom: theme.spacing.l,
-  },
-  createTaskButton: {
-    backgroundColor: theme.colors.light.primary,
-    paddingVertical: theme.spacing.m,
-    paddingHorizontal: theme.spacing.xl,
-    borderRadius: theme.radius.m,
-  },
-  createTaskButtonText: {
-    ...theme.typography.button,
-    color: theme.colors.common.white,
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'flex-end',
-  },
-  notificationsContainer: {
-    backgroundColor: theme.colors.light.background,
-    borderTopLeftRadius: theme.radius.xl,
-    borderTopRightRadius: theme.radius.xl,
-    height: '70%',
-    paddingBottom: 20,
-  },
-  notificationsHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: theme.spacing.l,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.light.border,
-  },
-  notificationsTitle: {
-    ...theme.typography.h3,
-  },
-  notificationItem: {
-    flexDirection: 'row',
-    padding: theme.spacing.l,
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.light.border,
-  },
-  unreadNotification: {
-    backgroundColor: theme.colors.light.highlight,
-  },
-  notificationContent: {
-    flex: 1,
-  },
-  notificationTitle: {
-    ...theme.typography.body,
-    fontWeight: '600',
-    marginBottom: 4,
-  },
-  notificationMessage: {
-    ...theme.typography.bodySmall,
-    color: theme.colors.light.subtext,
-    marginBottom: 4,
-  },
-  notificationTime: {
-    ...theme.typography.caption,
-    color: theme.colors.light.subtext,
-  },
-  unreadDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-    backgroundColor: theme.colors.light.primary,
-    alignSelf: 'center',
-    marginLeft: theme.spacing.s,
-  },
-  emptyNotifications: {
-    padding: theme.spacing.xl,
-    alignItems: 'center',
-  },
-  emptyNotificationsText: {
-    ...theme.typography.body,
-    color: theme.colors.light.subtext,
-  },
-});
+const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentTheme: typeof originalTheme) => 
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingHorizontal: currentTheme.spacing.l,
+      paddingTop: currentTheme.spacing.l,
+      paddingBottom: currentTheme.spacing.m,
+    },
+    greeting: {
+      ...currentTheme.typography.h2,
+      color: colors.text, 
+      marginBottom: currentTheme.spacing.xs,
+    },
+    locationContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    locationText: { 
+      ...currentTheme.typography.bodySmall,
+      color: colors.subtext, 
+      marginLeft: currentTheme.spacing.xs,
+    },
+    notificationButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      backgroundColor: colors.card, 
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    notificationBadge: {
+      position: 'absolute',
+      top: 8,
+      right: 8,
+      width: 8, // Original size
+      height: 8,
+      borderRadius: 4,
+      backgroundColor: colors.error, 
+    },
+    searchContainer: {
+      paddingHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.l,
+    },
+    categoriesSection: {
+      marginBottom: currentTheme.spacing.l,
+    },
+    sectionHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      paddingHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.m,
+    },
+    sectionTitle: {
+      ...currentTheme.typography.h3,
+      color: colors.text, 
+    },
+    seeAllText: {
+      ...currentTheme.typography.bodySmall,
+      color: colors.primary, 
+      fontWeight: '600',
+    },
+    categoriesList: {
+      paddingHorizontal: currentTheme.spacing.l,
+    },
+    section: {
+      marginBottom: currentTheme.spacing.xl,
+    },
+    taskersList: {
+      paddingHorizontal: currentTheme.spacing.l,
+    },
+    taskerCardContainer: {
+      width: 280,
+      marginRight: currentTheme.spacing.m,
+    },
+    emptyTasksContainer: {
+      alignItems: 'center',
+      padding: currentTheme.spacing.xl,
+      backgroundColor: colors.card, 
+      borderRadius: currentTheme.radius.l,
+      marginHorizontal: currentTheme.spacing.l,
+    },
+    emptyTasksImage: {
+      width: 120,
+      height: 120,
+      marginBottom: currentTheme.spacing.l,
+    },
+    emptyTasksTitle: {
+      ...currentTheme.typography.h3,
+      color: colors.text, 
+      marginBottom: currentTheme.spacing.s,
+    },
+    emptyTasksText: {
+      ...currentTheme.typography.body,
+      color: colors.subtext, 
+      textAlign: 'center',
+      marginBottom: currentTheme.spacing.l,
+    },
+    createTaskButton: {
+      backgroundColor: colors.primary, 
+      paddingVertical: currentTheme.spacing.m,
+      paddingHorizontal: currentTheme.spacing.xl,
+      borderRadius: currentTheme.radius.m,
+    },
+    createTaskButtonText: {
+      ...currentTheme.typography.button,
+      color: currentTheme.colors.common.white, 
+    },
+    modalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)', 
+      justifyContent: 'flex-end',
+    },
+    notificationsModalContainer: { 
+      backgroundColor: colors.background, 
+      borderTopLeftRadius: currentTheme.radius.xl,
+      borderTopRightRadius: currentTheme.radius.xl,
+      height: '70%', 
+      paddingBottom: currentTheme.spacing.m, 
+    },
+    notificationsHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: currentTheme.spacing.l,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border, 
+    },
+    notificationsTitle: { // Title for the modal "Notifications"
+      ...currentTheme.typography.h3,
+      color: colors.text, 
+    },
+    notificationItem: {
+      flexDirection: 'row',
+      padding: currentTheme.spacing.l,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border, 
+    },
+    unreadNotification: {
+      backgroundColor: colors.highlight, 
+    },
+    notificationContent: {
+      flex: 1,
+    },
+    notificationTitle: { // Title for individual notification item
+      ...currentTheme.typography.body,
+      fontWeight: '600',
+      color: colors.text, 
+      marginBottom: 4,
+    },
+    notificationMessage: {
+      ...currentTheme.typography.bodySmall,
+      color: colors.subtext, 
+      marginBottom: 4,
+    },
+    notificationTime: {
+      ...currentTheme.typography.caption,
+      color: colors.subtext, 
+    },
+    unreadDot: {
+      width: 10,
+      height: 10,
+      borderRadius: 5,
+      backgroundColor: colors.primary, 
+      alignSelf: 'center',
+      marginLeft: currentTheme.spacing.s,
+    },
+    emptyNotifications: { 
+      padding: currentTheme.spacing.xl,
+      alignItems: 'center',
+    },
+    emptyNotificationsText: {
+      ...currentTheme.typography.body,
+      color: colors.subtext, 
+    },
+  });
+
+export default HomeScreen;

--- a/Handlr/app/(tabs)/profile.tsx
+++ b/Handlr/app/(tabs)/profile.tsx
@@ -87,7 +87,7 @@ export default function ProfileScreen() {
           value={item.value}
           onValueChange={item.onToggle}
           trackColor={{ false: colors.inactive, true: colors.primary }}
-          thumbColor={colors.white} 
+          thumbColor={originalTheme.colors.common.white} 
         />
       ) : item.rightText ? (
         <View style={styles.menuItemRight}>
@@ -363,7 +363,7 @@ const dynamicStyles = (colors: AppColorsType, currentTheme: typeof originalTheme
     marginLeft: currentTheme.spacing.s,
   },
   menuItemBadgeText: {
-    color: colors.white,
+    color: originalTheme.colors.common.white,
     fontSize: 10,
     fontWeight: '600',
   },

--- a/Handlr/app/profile/edit.tsx
+++ b/Handlr/app/profile/edit.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react'; // Added useEffect for header options
 import { 
   View, 
   Text, 
@@ -9,17 +9,23 @@ import {
   ScrollView, 
   KeyboardAvoidingView, 
   Platform,
-  Alert
+  Alert,
+  Dimensions // For screenWidth fallback
 } from 'react-native';
-import { router, Stack } from 'expo-router';
+import { router, Stack, useNavigation } from 'expo-router'; // Added useNavigation
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { ChevronLeft, Camera, X, Check } from 'lucide-react-native';
+import { ChevronLeft, Camera, Check } from 'lucide-react-native';
 import * as ImagePicker from 'expo-image-picker';
-import theme from '@/constants/theme';
+import originalTheme from '@/constants/theme'; // Renamed
+import { useTheme } from '../../../context/ThemeContext'; // Corrected path
 import Button from '@/components/Button';
 import { useAuthStore } from '@/store/authStore';
 
 export default function EditProfileScreen() {
+  const { colors } = useTheme(); 
+  const styles = dynamicStyles(colors, originalTheme); 
+  const navigation = useNavigation(); 
+
   const { user, updateUserProfile } = useAuthStore();
   
   const [name, setName] = useState(user?.name || '');
@@ -30,21 +36,43 @@ export default function EditProfileScreen() {
   const [avatar, setAvatar] = useState(user?.avatar || 'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80');
   const [isLoading, setIsLoading] = useState(false);
 
+  // Dynamically set header options based on theme
+  useEffect(() => {
+    navigation.setOptions({
+      headerStyle: { backgroundColor: colors.background },
+      headerTitleStyle: { color: colors.text },
+      headerLeft: () => (
+        <TouchableOpacity 
+          style={styles.headerButton}
+          onPress={() => router.back()}
+        >
+          <ChevronLeft size={24} color={colors.text} /> 
+        </TouchableOpacity>
+      ),
+      headerRight: () => (
+        <TouchableOpacity 
+          style={styles.headerButton}
+          onPress={handleSave}
+          disabled={isLoading}
+        >
+          <Check size={24} color={colors.primary} /> 
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, colors, isLoading, name, email, phone, bio, address, avatar]); // Added relevant dependencies
+
   const pickImage = async () => {
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
-    
     if (status !== 'granted') {
       Alert.alert('Permission Denied', 'We need camera roll permission to upload your profile picture');
       return;
     }
-
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,
     });
-
     if (!result.canceled && result.assets && result.assets.length > 0) {
       setAvatar(result.assets[0].uri);
     }
@@ -55,43 +83,16 @@ export default function EditProfileScreen() {
       Alert.alert('Error', 'Name is required');
       return;
     }
-
     setIsLoading(true);
-    
     try {
-      // In a real app, this would upload the image to a server
-      // and update the user profile in the database
-      
-      // Simulate API call
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
-      if (!user) {
-        throw new Error("User not found");
-      }
-      
+      await new Promise(resolve => setTimeout(resolve, 1000)); // Simulate API
+      if (!user) throw new Error("User not found");
       const updatedUser = {
-        ...user,
-        name,
-        email,
-        phone,
-        bio,
-        avatar,
-        location: {
-          address,
-          coordinates: user.location?.coordinates || {
-            latitude: 12.9716,
-            longitude: 77.5946
-          }
-        }
+        ...user, name, email, phone, bio, avatar,
+        location: { address, coordinates: user.location?.coordinates || { latitude: 12.9716, longitude: 77.5946 } }
       };
-      
       updateUserProfile(updatedUser);
-      
-      Alert.alert(
-        'Success',
-        'Profile updated successfully',
-        [{ text: 'OK', onPress: () => router.back() }]
-      );
+      Alert.alert('Success', 'Profile updated successfully', [{ text: 'OK', onPress: () => router.back() }]);
     } catch (error) {
       Alert.alert('Error', 'Failed to update profile');
     } finally {
@@ -101,45 +102,18 @@ export default function EditProfileScreen() {
 
   return (
     <>
-      <Stack.Screen 
-        options={{
-          title: 'Edit Profile',
-          headerLeft: () => (
-            <TouchableOpacity 
-              style={styles.headerButton}
-              onPress={() => router.back()}
-            >
-              <ChevronLeft size={24} color={theme.colors.light.text} />
-            </TouchableOpacity>
-          ),
-          headerRight: () => (
-            <TouchableOpacity 
-              style={styles.headerButton}
-              onPress={handleSave}
-              disabled={isLoading}
-            >
-              <Check size={24} color={theme.colors.light.primary} />
-            </TouchableOpacity>
-          ),
-        }} 
-      />
+      {/* Stack.Screen options are now set dynamically via useEffect and setOptions */}
       <KeyboardAvoidingView
-        style={{ flex: 1 }}
+        style={{ flex: 1, backgroundColor: colors.background }} 
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 90 : 0} 
       >
         <SafeAreaView style={styles.container} edges={['bottom']}>
           <ScrollView showsVerticalScrollIndicator={false}>
             <View style={styles.avatarContainer}>
-              <Image
-                source={{ uri: avatar }}
-                style={styles.avatar}
-              />
-              <TouchableOpacity 
-                style={styles.cameraButton}
-                onPress={pickImage}
-              >
-                <Camera size={20} color={theme.colors.common.white} />
+              <Image source={{ uri: avatar }} style={styles.avatar} />
+              <TouchableOpacity style={styles.cameraButton} onPress={pickImage}>
+                <Camera size={20} color={originalTheme.colors.common.white} />
               </TouchableOpacity>
             </View>
 
@@ -151,6 +125,7 @@ export default function EditProfileScreen() {
                   value={name}
                   onChangeText={setName}
                   placeholder="Enter your full name"
+                  placeholderTextColor={colors.placeholder}
                 />
               </View>
 
@@ -163,6 +138,7 @@ export default function EditProfileScreen() {
                   placeholder="Enter your email"
                   keyboardType="email-address"
                   autoCapitalize="none"
+                  placeholderTextColor={colors.placeholder}
                 />
               </View>
 
@@ -177,6 +153,7 @@ export default function EditProfileScreen() {
                     placeholder="Enter your phone number"
                     keyboardType="phone-pad"
                     maxLength={10}
+                    placeholderTextColor={colors.placeholder}
                   />
                 </View>
               </View>
@@ -191,6 +168,7 @@ export default function EditProfileScreen() {
                   multiline
                   numberOfLines={4}
                   textAlignVertical="top"
+                  placeholderTextColor={colors.placeholder}
                 />
               </View>
 
@@ -204,6 +182,7 @@ export default function EditProfileScreen() {
                   multiline
                   numberOfLines={3}
                   textAlignVertical="top"
+                  placeholderTextColor={colors.placeholder}
                 />
               </View>
             </View>
@@ -223,84 +202,89 @@ export default function EditProfileScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: theme.colors.light.background,
-  },
-  headerButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  avatarContainer: {
-    alignItems: 'center',
-    marginTop: theme.spacing.xl,
-    marginBottom: theme.spacing.xl,
-  },
-  avatar: {
-    width: 120,
-    height: 120,
-    borderRadius: 60,
-  },
-  cameraButton: {
-    position: 'absolute',
-    bottom: 0,
-    right: theme.sizes.screenWidth / 2 - 60,
-    backgroundColor: theme.colors.light.primary,
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderWidth: 3,
-    borderColor: theme.colors.light.background,
-  },
-  formContainer: {
-    paddingHorizontal: theme.spacing.l,
-  },
-  formGroup: {
-    marginBottom: theme.spacing.l,
-  },
-  label: {
-    ...theme.typography.bodySmall,
-    fontWeight: '600',
-    marginBottom: theme.spacing.xs,
-  },
-  input: {
-    borderWidth: 1,
-    borderColor: theme.colors.light.border,
-    borderRadius: theme.radius.m,
-    paddingHorizontal: theme.spacing.m,
-    paddingVertical: theme.spacing.m,
-    ...theme.typography.body,
-  },
-  textArea: {
-    minHeight: 100,
-    textAlignVertical: 'top',
-  },
-  phoneInputContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderWidth: 1,
-    borderColor: theme.colors.light.border,
-    borderRadius: theme.radius.m,
-    paddingHorizontal: theme.spacing.m,
-  },
-  countryCode: {
-    ...theme.typography.body,
-    fontWeight: '600',
-    marginRight: theme.spacing.s,
-  },
-  phoneInput: {
-    flex: 1,
-    paddingVertical: theme.spacing.m,
-    ...theme.typography.body,
-  },
-  buttonContainer: {
-    padding: theme.spacing.l,
-    marginBottom: theme.spacing.xxl,
-  },
-});
+const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentTheme: typeof originalTheme) => 
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background, 
+    },
+    headerButton: { 
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    avatarContainer: {
+      alignItems: 'center',
+      marginTop: currentTheme.spacing.xl,
+      marginBottom: currentTheme.spacing.xl,
+    },
+    avatar: {
+      width: 120,
+      height: 120,
+      borderRadius: 60,
+    },
+    cameraButton: {
+      position: 'absolute',
+      bottom: 0,
+      right: (currentTheme.sizes?.screenWidth || Dimensions.get('window').width) / 2 - 60, 
+      backgroundColor: colors.primary, 
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderWidth: 3,
+      borderColor: colors.background, 
+    },
+    formContainer: {
+      paddingHorizontal: currentTheme.spacing.l,
+    },
+    formGroup: {
+      marginBottom: currentTheme.spacing.l,
+    },
+    label: {
+      ...currentTheme.typography.bodySmall,
+      fontWeight: '600',
+      marginBottom: currentTheme.spacing.xs,
+      color: colors.text, 
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: colors.border, 
+      borderRadius: currentTheme.radius.m,
+      paddingHorizontal: currentTheme.spacing.m,
+      paddingVertical: currentTheme.spacing.m,
+      ...currentTheme.typography.body,
+      color: colors.text, 
+    },
+    textArea: {
+      minHeight: 100,
+      textAlignVertical: 'top',
+    },
+    phoneInputContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      borderWidth: 1,
+      borderColor: colors.border, 
+      borderRadius: currentTheme.radius.m,
+      paddingHorizontal: currentTheme.spacing.m,
+    },
+    countryCode: {
+      ...currentTheme.typography.body,
+      fontWeight: '600',
+      marginRight: currentTheme.spacing.s,
+      color: colors.text, 
+    },
+    phoneInput: {
+      flex: 1,
+      paddingVertical: currentTheme.spacing.m,
+      ...currentTheme.typography.body,
+      color: colors.text, 
+    },
+    buttonContainer: {
+      padding: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.xxl, 
+    },
+  });

--- a/Handlr/app/profile/payment-methods.tsx
+++ b/Handlr/app/profile/payment-methods.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react'; // Added useEffect
 import { 
   View, 
   Text, 
@@ -9,7 +9,7 @@ import {
   Alert,
   Modal
 } from 'react-native';
-import { router, Stack } from 'expo-router';
+import { router, Stack, useNavigation } from 'expo-router'; // Added useNavigation
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { 
   ChevronLeft, 
@@ -20,78 +20,61 @@ import {
   X,
   AlertCircle
 } from 'lucide-react-native';
-import theme from '@/constants/theme';
+import originalTheme from '@/constants/theme'; // Renamed
+import { useTheme } from '../../../context/ThemeContext'; // Added
 import Button from '@/components/Button';
 
-// Mock payment methods
+// Mock payment methods (data remains the same)
 const mockPaymentMethods = [
-  {
-    id: '1',
-    type: 'card',
-    name: 'HDFC Credit Card',
-    number: '•••• •••• •••• 4242',
-    expiry: '12/25',
-    isDefault: true,
-    icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/Mastercard-logo.svg/200px-Mastercard-logo.svg.png',
-  },
-  {
-    id: '2',
-    type: 'upi',
-    name: 'Google Pay',
-    number: 'user@okicici',
-    isDefault: false,
-    icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c7/Google_Pay_Logo_%282020%29.svg/200px-Google_Pay_Logo_%282020%29.svg.png',
-  },
-  {
-    id: '3',
-    type: 'wallet',
-    name: 'Paytm Wallet',
-    number: '+91 98765 43210',
-    isDefault: false,
-    icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/Paytm_Logo_%28standalone%29.svg/200px-Paytm_Logo_%28standalone%29.svg.png',
-  },
+  { id: '1', type: 'card', name: 'HDFC Credit Card', number: '•••• •••• •••• 4242', expiry: '12/25', isDefault: true, icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/Mastercard-logo.svg/200px-Mastercard-logo.svg.png', },
+  { id: '2', type: 'upi', name: 'Google Pay', number: 'user@okicici', isDefault: false, icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c7/Google_Pay_Logo_%282020%29.svg/200px-Google_Pay_Logo_%282020%29.svg.png', },
+  { id: '3', type: 'wallet', name: 'Paytm Wallet', number: '+91 98765 43210', isDefault: false, icon: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/Paytm_Logo_%28standalone%29.svg/200px-Paytm_Logo_%28standalone%29.svg.png', },
 ];
 
 export default function PaymentMethodsScreen() {
+  const { colors } = useTheme();
+  const navigation = useNavigation();
+  const styles = dynamicStyles(colors, originalTheme);
+
   const [paymentMethods, setPaymentMethods] = useState(mockPaymentMethods);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [selectedMethod, setSelectedMethod] = useState<string | null>(null);
 
+  useEffect(() => {
+    navigation.setOptions({
+      headerStyle: { backgroundColor: colors.background },
+      headerTitleStyle: { color: colors.text },
+      headerLeft: () => (
+        <TouchableOpacity 
+          style={styles.headerButton} // Layout only
+          onPress={() => router.back()}
+        >
+          <ChevronLeft size={24} color={colors.text} />
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, colors]);
+
   const handleAddPaymentMethod = () => {
-    // In a real app, this would navigate to a screen to add a new payment method
-    Alert.alert(
-      "Add Payment Method",
-      "This would open a screen to add a new payment method in a real app."
-    );
+    Alert.alert("Add Payment Method", "This would open a screen to add a new payment method.");
   };
 
   const handleSetDefault = (id: string) => {
     setPaymentMethods(methods => 
-      methods.map(method => ({
-        ...method,
-        isDefault: method.id === id
-      }))
+      methods.map(method => ({ ...method, isDefault: method.id === id }))
     );
   };
 
   const handleDeleteConfirm = () => {
     if (selectedMethod) {
-      // Check if trying to delete default method
       const isDefault = paymentMethods.find(m => m.id === selectedMethod)?.isDefault;
-      
       if (isDefault) {
-        Alert.alert(
-          "Cannot Delete Default",
-          "Please set another payment method as default before deleting this one."
-        );
+        Alert.alert("Cannot Delete Default", "Please set another payment method as default first.");
         setShowDeleteModal(false);
         setSelectedMethod(null);
         return;
       }
-      
-      setPaymentMethods(methods => 
-        methods.filter(method => method.id !== selectedMethod)
-      );
+      setPaymentMethods(methods => methods.filter(method => method.id !== selectedMethod));
       setShowDeleteModal(false);
       setSelectedMethod(null);
     }
@@ -104,26 +87,14 @@ export default function PaymentMethodsScreen() {
 
   return (
     <>
-      <Stack.Screen 
-        options={{
-          title: 'Payment Methods',
-          headerLeft: () => (
-            <TouchableOpacity 
-              style={styles.headerButton}
-              onPress={() => router.back()}
-            >
-              <ChevronLeft size={24} color={theme.colors.light.text} />
-            </TouchableOpacity>
-          ),
-        }} 
-      />
+      {/* Stack.Screen options are now set dynamically via useEffect */}
       <SafeAreaView style={styles.container} edges={['bottom']}>
         <ScrollView showsVerticalScrollIndicator={false}>
           <View style={styles.addButtonContainer}>
             <Button
               title="Add Payment Method"
               onPress={handleAddPaymentMethod}
-              leftIcon={<Plus size={18} color={theme.colors.common.white} />}
+              leftIcon={<Plus size={18} color={originalTheme.colors.common.white} />} // Explicitly white icon
             />
           </View>
 
@@ -157,7 +128,7 @@ export default function PaymentMethodsScreen() {
                   <View style={styles.paymentMethodActions}>
                     {method.isDefault ? (
                       <View style={styles.defaultBadge}>
-                        <CheckCircle size={14} color={theme.colors.light.success} />
+                        <CheckCircle size={14} color={colors.success} />
                         <Text style={styles.defaultText}>Default</Text>
                       </View>
                     ) : (
@@ -172,7 +143,7 @@ export default function PaymentMethodsScreen() {
                       style={styles.deleteButton}
                       onPress={() => handleDelete(method.id)}
                     >
-                      <Trash2 size={18} color={theme.colors.light.error} />
+                      <Trash2 size={18} color={colors.error} />
                     </TouchableOpacity>
                   </View>
                 </View>
@@ -180,7 +151,7 @@ export default function PaymentMethodsScreen() {
             </View>
           ) : (
             <View style={styles.emptyContainer}>
-              <CreditCard size={60} color={theme.colors.light.subtext} />
+              <CreditCard size={60} color={colors.subtext} />
               <Text style={styles.emptyTitle}>No Payment Methods</Text>
               <Text style={styles.emptyText}>
                 Add a payment method to easily pay for tasks
@@ -188,9 +159,9 @@ export default function PaymentMethodsScreen() {
             </View>
           )}
 
-          <View style={styles.securityNote}>
+          <View style={styles.securityNoteContainer}>
             <View style={styles.securityIcon}>
-              <AlertCircle size={20} color={theme.colors.light.primary} />
+              <AlertCircle size={20} color={colors.primary} />
             </View>
             <Text style={styles.securityText}>
               Your payment information is encrypted and stored securely. We use industry-standard security measures to protect your data.
@@ -199,7 +170,6 @@ export default function PaymentMethodsScreen() {
         </ScrollView>
       </SafeAreaView>
 
-      {/* Delete Confirmation Modal */}
       <Modal
         visible={showDeleteModal}
         transparent={true}
@@ -211,7 +181,7 @@ export default function PaymentMethodsScreen() {
             <View style={styles.modalHeader}>
               <Text style={styles.modalTitle}>Delete Payment Method</Text>
               <TouchableOpacity onPress={() => setShowDeleteModal(false)}>
-                <X size={24} color={theme.colors.light.text} />
+                <X size={24} color={colors.text} />
               </TouchableOpacity>
             </View>
             <Text style={styles.modalText}>
@@ -227,9 +197,9 @@ export default function PaymentMethodsScreen() {
               <Button
                 title="Delete"
                 onPress={handleDeleteConfirm}
-                variant="primary"
+                variant="primary" // This will use primary bg, text should be white
                 style={[styles.modalButton, styles.deleteModalButton]}
-                textStyle={{ color: theme.colors.common.white }}
+                textStyle={{ color: originalTheme.colors.common.white }} // Explicitly white text
               />
             </View>
           </View>
@@ -239,178 +209,184 @@ export default function PaymentMethodsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: theme.colors.light.background,
-  },
-  headerButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  addButtonContainer: {
-    padding: theme.spacing.l,
-  },
-  sectionTitle: {
-    paddingHorizontal: theme.spacing.l,
-    marginBottom: theme.spacing.s,
-  },
-  sectionTitleText: {
-    ...theme.typography.bodySmall,
-    color: theme.colors.light.subtext,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-  },
-  paymentMethodsContainer: {
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    marginHorizontal: theme.spacing.l,
-    marginBottom: theme.spacing.l,
-    overflow: 'hidden',
-  },
-  paymentMethodItem: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    padding: theme.spacing.l,
-  },
-  paymentMethodItemBorder: {
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.light.border,
-  },
-  paymentMethodLeft: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flex: 1,
-  },
-  paymentMethodIcon: {
-    width: 40,
-    height: 40,
-    resizeMode: 'contain',
-    marginRight: theme.spacing.m,
-  },
-  paymentMethodInfo: {
-    flex: 1,
-  },
-  paymentMethodName: {
-    ...theme.typography.body,
-    fontWeight: '600',
-    marginBottom: 2,
-  },
-  paymentMethodNumber: {
-    ...theme.typography.bodySmall,
-    color: theme.colors.light.subtext,
-    marginBottom: 2,
-  },
-  paymentMethodExpiry: {
-    ...theme.typography.caption,
-    color: theme.colors.light.subtext,
-  },
-  paymentMethodActions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  defaultBadge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: theme.colors.light.success + '20',
-    paddingHorizontal: theme.spacing.s,
-    paddingVertical: 4,
-    borderRadius: theme.radius.s,
-    marginRight: theme.spacing.s,
-  },
-  defaultText: {
-    ...theme.typography.caption,
-    color: theme.colors.light.success,
-    fontWeight: '600',
-    marginLeft: 4,
-  },
-  setDefaultButton: {
-    paddingHorizontal: theme.spacing.s,
-    paddingVertical: 4,
-    marginRight: theme.spacing.s,
-  },
-  setDefaultText: {
-    ...theme.typography.caption,
-    color: theme.colors.light.primary,
-    fontWeight: '600',
-  },
-  deleteButton: {
-    padding: theme.spacing.xs,
-  },
-  emptyContainer: {
-    alignItems: 'center',
-    padding: theme.spacing.xl,
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    marginHorizontal: theme.spacing.l,
-    marginBottom: theme.spacing.l,
-  },
-  emptyTitle: {
-    ...theme.typography.h3,
-    marginTop: theme.spacing.m,
-    marginBottom: theme.spacing.s,
-  },
-  emptyText: {
-    ...theme.typography.body,
-    color: theme.colors.light.subtext,
-    textAlign: 'center',
-  },
-  securityNote: {
-    flexDirection: 'row',
-    backgroundColor: theme.colors.light.highlight,
-    borderRadius: theme.radius.l,
-    padding: theme.spacing.m,
-    marginHorizontal: theme.spacing.l,
-    marginBottom: theme.spacing.xxl,
-  },
-  securityIcon: {
-    marginRight: theme.spacing.m,
-  },
-  securityText: {
-    ...theme.typography.caption,
-    color: theme.colors.light.subtext,
-    flex: 1,
-    lineHeight: 18,
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  modalContainer: {
-    backgroundColor: theme.colors.light.background,
-    borderRadius: theme.radius.l,
-    width: '80%',
-    padding: theme.spacing.l,
-  },
-  modalHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: theme.spacing.m,
-  },
-  modalTitle: {
-    ...theme.typography.h3,
-  },
-  modalText: {
-    ...theme.typography.body,
-    color: theme.colors.light.subtext,
-    marginBottom: theme.spacing.l,
-  },
-  modalButtons: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
-  modalButton: {
-    flex: 1,
-    marginHorizontal: theme.spacing.xs,
-  },
-  deleteModalButton: {
-    backgroundColor: theme.colors.light.error,
-  },
-});
+const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentTheme: typeof originalTheme) => 
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    headerButton: { // Layout only
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    addButtonContainer: {
+      padding: currentTheme.spacing.l,
+    },
+    sectionTitle: {
+      paddingHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.s,
+    },
+    sectionTitleText: {
+      ...currentTheme.typography.bodySmall,
+      color: colors.subtext,
+      fontWeight: '600',
+      textTransform: 'uppercase',
+    },
+    paymentMethodsContainer: {
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+      marginHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.l,
+      overflow: 'hidden',
+    },
+    paymentMethodItem: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: currentTheme.spacing.l,
+    },
+    paymentMethodItemBorder: { // Applied to paymentMethodItem
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+    },
+    paymentMethodLeft: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flex: 1,
+    },
+    paymentMethodIcon: {
+      width: 40,
+      height: 40,
+      resizeMode: 'contain',
+      marginRight: currentTheme.spacing.m,
+    },
+    paymentMethodInfo: {
+      flex: 1,
+    },
+    paymentMethodName: {
+      ...currentTheme.typography.body,
+      fontWeight: '600',
+      color: colors.text, // Added
+      marginBottom: 2,
+    },
+    paymentMethodNumber: {
+      ...currentTheme.typography.bodySmall,
+      color: colors.subtext,
+      marginBottom: 2,
+    },
+    paymentMethodExpiry: {
+      ...currentTheme.typography.caption,
+      color: colors.subtext,
+    },
+    paymentMethodActions: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    defaultBadge: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.success + '20', // Updated
+      paddingHorizontal: currentTheme.spacing.s,
+      paddingVertical: 4,
+      borderRadius: currentTheme.radius.s,
+      marginRight: currentTheme.spacing.s,
+    },
+    defaultText: {
+      ...currentTheme.typography.caption,
+      color: colors.success,
+      fontWeight: '600',
+      marginLeft: 4,
+    },
+    setDefaultButton: {
+      paddingHorizontal: currentTheme.spacing.s,
+      paddingVertical: 4,
+      marginRight: currentTheme.spacing.s,
+    },
+    setDefaultText: {
+      ...currentTheme.typography.caption,
+      color: colors.primary,
+      fontWeight: '600',
+    },
+    deleteButton: { // Layout for TouchableOpacity containing Trash2 icon
+      padding: currentTheme.spacing.xs,
+    },
+    emptyContainer: {
+      alignItems: 'center',
+      padding: currentTheme.spacing.xl,
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+      marginHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.l,
+    },
+    emptyTitle: {
+      ...currentTheme.typography.h3,
+      color: colors.text, // Added
+      marginTop: currentTheme.spacing.m,
+      marginBottom: currentTheme.spacing.s,
+    },
+    emptyText: {
+      ...currentTheme.typography.body,
+      color: colors.subtext,
+      textAlign: 'center',
+    },
+    securityNoteContainer: { // Renamed from securityNote for clarity
+      flexDirection: 'row',
+      backgroundColor: colors.highlight,
+      borderRadius: currentTheme.radius.l,
+      padding: currentTheme.spacing.m,
+      marginHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.xxl,
+    },
+    securityIcon: { // Layout for AlertCircle icon
+      marginRight: currentTheme.spacing.m,
+    },
+    securityText: {
+      ...currentTheme.typography.caption,
+      color: colors.subtext,
+      flex: 1,
+      lineHeight: 18,
+    },
+    modalOverlay: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.5)', // Standard overlay
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    modalContainer: {
+      backgroundColor: colors.background,
+      borderRadius: currentTheme.radius.l,
+      width: '80%',
+      padding: currentTheme.spacing.l,
+    },
+    modalHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: currentTheme.spacing.m,
+    },
+    modalTitle: {
+      ...currentTheme.typography.h3,
+      color: colors.text, // Added
+    },
+    modalText: {
+      ...currentTheme.typography.body,
+      color: colors.subtext,
+      marginBottom: currentTheme.spacing.l,
+    },
+    modalButtons: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+    },
+    modalButton: { // For layout of individual button in modal
+      flex: 1,
+      marginHorizontal: currentTheme.spacing.xs,
+    },
+    deleteModalButton: { // Specific style for delete button background
+      backgroundColor: colors.error, 
+    },
+  });
+
+export default PaymentMethodsScreen;

--- a/Handlr/app/profile/personal-info.tsx
+++ b/Handlr/app/profile/personal-info.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react'; // Added useEffect
 import { 
   View, 
   Text, 
@@ -6,49 +6,53 @@ import {
   ScrollView, 
   TouchableOpacity 
 } from 'react-native';
-import { router, Stack } from 'expo-router';
+import { router, Stack, useNavigation } from 'expo-router'; // Added useNavigation
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ChevronLeft, Edit2 } from 'lucide-react-native';
-import theme from '@/constants/theme';
+import originalTheme from '@/constants/theme'; // Renamed
+import { useTheme } from '../../../context/ThemeContext'; // Added
 import { useAuthStore } from '@/store/authStore';
 
 export default function PersonalInfoScreen() {
+  const { colors } = useTheme();
+  const navigation = useNavigation();
+  const styles = dynamicStyles(colors, originalTheme);
+
   const { user } = useAuthStore();
 
   const personalInfo = [
-    {
-      title: 'Full Name',
-      value: user?.name || 'Not provided',
-    },
-    {
-      title: 'Phone Number',
-      value: user?.phone || 'Not provided',
-    },
-    {
-      title: 'Email',
-      value: user?.email || 'Not provided',
-    },
-    {
-      title: 'Address',
-      value: user?.location?.address || 'Not provided',
-    },
-    {
-      title: 'Date of Birth',
-      value: 'Not provided',
-    },
-    {
-      title: 'Gender',
-      value: 'Not provided',
-    },
-    {
-      title: 'Emergency Contact',
-      value: 'Not provided',
-    },
-    {
-      title: 'Language',
-      value: 'English',
-    },
+    { title: 'Full Name', value: user?.name || 'Not provided', },
+    { title: 'Phone Number', value: user?.phone || 'Not provided', },
+    { title: 'Email', value: user?.email || 'Not provided', },
+    { title: 'Address', value: user?.location?.address || 'Not provided', },
+    { title: 'Date of Birth', value: 'Not provided', },
+    { title: 'Gender', value: 'Not provided', },
+    { title: 'Emergency Contact', value: 'Not provided', },
+    { title: 'Language', value: 'English', },
   ];
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerStyle: { backgroundColor: colors.background },
+      headerTitleStyle: { color: colors.text },
+      headerLeft: () => (
+        <TouchableOpacity 
+          style={styles.headerButton} // Layout only
+          onPress={() => router.back()}
+        >
+          <ChevronLeft size={24} color={colors.text} />
+        </TouchableOpacity>
+      ),
+      headerRight: () => (
+        <TouchableOpacity 
+          style={styles.headerButton} // Layout only
+          onPress={handleEdit}
+        >
+          <Edit2 size={20} color={colors.primary} />
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, colors]);
 
   const handleEdit = () => {
     router.push('/profile/edit');
@@ -56,27 +60,7 @@ export default function PersonalInfoScreen() {
 
   return (
     <>
-      <Stack.Screen 
-        options={{
-          title: 'Personal Information',
-          headerLeft: () => (
-            <TouchableOpacity 
-              style={styles.headerButton}
-              onPress={() => router.back()}
-            >
-              <ChevronLeft size={24} color={theme.colors.light.text} />
-            </TouchableOpacity>
-          ),
-          headerRight: () => (
-            <TouchableOpacity 
-              style={styles.headerButton}
-              onPress={handleEdit}
-            >
-              <Edit2 size={20} color={theme.colors.light.primary} />
-            </TouchableOpacity>
-          ),
-        }} 
-      />
+      {/* Stack.Screen options are now set dynamically via useEffect */}
       <SafeAreaView style={styles.container} edges={['bottom']}>
         <ScrollView showsVerticalScrollIndicator={false}>
           <View style={styles.infoContainer}>
@@ -85,7 +69,8 @@ export default function PersonalInfoScreen() {
                 key={index} 
                 style={[
                   styles.infoItem,
-                  index !== personalInfo.length - 1 && styles.infoItemBorder
+                  // Apply borderBottom only if not the last item
+                  index !== personalInfo.length - 1 && { borderBottomColor: colors.border, borderBottomWidth: 1 }
                 ]}
               >
                 <Text style={styles.infoTitle}>{item.title}</Text>
@@ -106,13 +91,13 @@ export default function PersonalInfoScreen() {
           </View>
 
           <View style={styles.infoContainer}>
-            <View style={styles.infoItem}>
+            <View style={[styles.infoItem, { borderBottomColor: colors.border, borderBottomWidth: 1 }]}>
               <Text style={styles.infoTitle}>Account Type</Text>
               <Text style={styles.infoValue}>
                 {user?.role === 'tasker' ? 'Tasker' : 'User'}
               </Text>
             </View>
-            <View style={[styles.infoItem, styles.infoItemBorder]}>
+            <View style={[styles.infoItem, { borderBottomColor: colors.border, borderBottomWidth: 1 }]}>
               <Text style={styles.infoTitle}>Member Since</Text>
               <Text style={styles.infoValue}>
                 {user?.createdAt 
@@ -145,77 +130,79 @@ export default function PersonalInfoScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: theme.colors.light.background,
-  },
-  headerButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  infoContainer: {
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    marginHorizontal: theme.spacing.l,
-    marginTop: theme.spacing.l,
-    marginBottom: theme.spacing.l,
-    overflow: 'hidden',
-  },
-  infoItem: {
-    padding: theme.spacing.l,
-  },
-  infoItemBorder: {
-    borderBottomWidth: 1,
-    borderBottomColor: theme.colors.light.border,
-  },
-  infoTitle: {
-    ...theme.typography.bodySmall,
-    color: theme.colors.light.subtext,
-    marginBottom: theme.spacing.xs,
-  },
-  infoValue: {
-    ...theme.typography.body,
-    fontWeight: '500',
-  },
-  infoValueEmpty: {
-    color: theme.colors.light.subtext,
-    fontStyle: 'italic',
-  },
-  sectionTitle: {
-    paddingHorizontal: theme.spacing.l,
-    marginBottom: theme.spacing.s,
-    marginTop: theme.spacing.l,
-  },
-  sectionTitleText: {
-    ...theme.typography.bodySmall,
-    color: theme.colors.light.subtext,
-    fontWeight: '600',
-    textTransform: 'uppercase',
-  },
-  statusBadge: {
-    alignSelf: 'flex-start',
-    backgroundColor: theme.colors.light.success,
-    paddingHorizontal: theme.spacing.m,
-    paddingVertical: theme.spacing.xs,
-    borderRadius: theme.radius.m,
-    marginTop: theme.spacing.xs,
-  },
-  statusText: {
-    color: theme.colors.common.white,
-    ...theme.typography.caption,
-    fontWeight: '600',
-  },
-  noteContainer: {
-    padding: theme.spacing.l,
-    marginBottom: theme.spacing.xxl,
-  },
-  noteText: {
-    ...theme.typography.caption,
-    color: theme.colors.light.subtext,
-    lineHeight: 18,
-  },
-});
+const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentTheme: typeof originalTheme) => 
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    headerButton: { // Layout only
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    infoContainer: {
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+      marginHorizontal: currentTheme.spacing.l,
+      marginTop: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.l,
+      overflow: 'hidden', // To respect borderRadius with borders
+    },
+    infoItem: {
+      padding: currentTheme.spacing.l,
+      // borderBottomColor and borderBottomWidth are applied conditionally
+    },
+    // infoItemBorder style is removed, merged into infoItem conditionally
+    infoTitle: {
+      ...currentTheme.typography.bodySmall,
+      color: colors.subtext,
+      marginBottom: currentTheme.spacing.xs,
+    },
+    infoValue: {
+      ...currentTheme.typography.body,
+      fontWeight: '500',
+      color: colors.text, // Added
+    },
+    infoValueEmpty: {
+      color: colors.subtext,
+      fontStyle: 'italic',
+    },
+    sectionTitle: {
+      paddingHorizontal: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.s,
+      marginTop: currentTheme.spacing.l,
+    },
+    sectionTitleText: {
+      ...currentTheme.typography.bodySmall,
+      color: colors.subtext,
+      fontWeight: '600',
+      textTransform: 'uppercase',
+    },
+    statusBadge: {
+      alignSelf: 'flex-start',
+      backgroundColor: colors.success,
+      paddingHorizontal: currentTheme.spacing.m,
+      paddingVertical: currentTheme.spacing.xs,
+      borderRadius: currentTheme.radius.m,
+      marginTop: currentTheme.spacing.xs,
+    },
+    statusText: {
+      color: currentTheme.colors.common.white, // Updated to common.white
+      ...currentTheme.typography.caption,
+      fontWeight: '600',
+    },
+    noteContainer: {
+      padding: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.xxl,
+    },
+    noteText: {
+      ...currentTheme.typography.caption,
+      color: colors.subtext,
+      lineHeight: 18,
+    },
+  });
+
+export default PersonalInfoScreen;

--- a/Handlr/app/profile/reviews.tsx
+++ b/Handlr/app/profile/reviews.tsx
@@ -1,19 +1,20 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react'; // Added useEffect
 import { 
   View, 
   Text, 
   StyleSheet, 
-  ScrollView, 
+  ScrollView, // ScrollView is imported but FlatList is used for main content
   TouchableOpacity,
   Image,
   FlatList
 } from 'react-native';
-import { router, Stack } from 'expo-router';
+import { router, Stack, useNavigation } from 'expo-router'; // Added useNavigation
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ChevronLeft, Star, ThumbsUp, ThumbsDown } from 'lucide-react-native';
-import theme from '@/constants/theme';
+import originalTheme from '@/constants/theme'; // Renamed
+import { useTheme } from '../../../context/ThemeContext'; // Added
 
-// Define review types
+// Define review types (assuming these are correct)
 interface ReviewGiven {
   id: string;
   taskId: string;
@@ -40,106 +41,61 @@ interface ReviewReceived {
   userReview: boolean;
 }
 
-// Mock reviews data
+// Mock reviews data (data remains the same)
 const mockReviews: ReviewGiven[] = [
-  {
-    id: '1',
-    taskId: '101',
-    taskTitle: 'Deep cleaning of 2BHK apartment',
-    taskerId: '1',
-    taskerName: 'Rajesh Kumar',
-    taskerAvatar: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80',
-    rating: 4.5,
-    comment: "Rajesh did an excellent job cleaning my apartment. He was thorough and paid attention to details. Would definitely hire again!",
-    date: '2023-06-10',
-    userReview: true,
-  },
-  {
-    id: '2',
-    taskId: '102',
-    taskTitle: 'Fix leaking bathroom tap',
-    taskerId: '2',
-    taskerName: 'Priya Singh',
-    taskerAvatar: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80',
-    rating: 5,
-    comment: "Priya was prompt and fixed the leaking tap quickly. Very professional and knowledgeable.",
-    date: '2023-06-05',
-    userReview: true,
-  },
-  {
-    id: '3',
-    taskId: '103',
-    taskTitle: 'Install new ceiling fan',
-    taskerId: '3',
-    taskerName: 'Amit Patel',
-    taskerAvatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80',
-    rating: 3.5,
-    comment: "Amit installed the fan correctly, but was a bit late. Otherwise, the work was satisfactory.",
-    date: '2023-05-28',
-    userReview: true,
-  },
+  { id: '1', taskId: '101', taskTitle: 'Deep cleaning of 2BHK apartment', taskerId: '1', taskerName: 'Rajesh Kumar', taskerAvatar: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80', rating: 4.5, comment: "Rajesh did an excellent job cleaning my apartment. He was thorough and paid attention to details. Would definitely hire again!", date: '2023-06-10', userReview: true, },
+  { id: '2', taskId: '102', taskTitle: 'Fix leaking bathroom tap', taskerId: '2', taskerName: 'Priya Singh', taskerAvatar: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80', rating: 5, comment: "Priya was prompt and fixed the leaking tap quickly. Very professional and knowledgeable.", date: '2023-06-05', userReview: true, },
+  { id: '3', taskId: '103', taskTitle: 'Install new ceiling fan', taskerId: '3', taskerName: 'Amit Patel', taskerAvatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80', rating: 3.5, comment: "Amit installed the fan correctly, but was a bit late. Otherwise, the work was satisfactory.", date: '2023-05-28', userReview: true, },
 ];
-
-// Mock reviews received (if user is also a tasker)
 const mockReviewsReceived: ReviewReceived[] = [
-  {
-    id: '4',
-    taskId: '104',
-    taskTitle: 'Garden maintenance',
-    userId: '101',
-    userName: 'Ananya Sharma',
-    userAvatar: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80',
-    rating: 4,
-    comment: "Good service, but could improve on timeliness.",
-    date: '2023-06-15',
-    userReview: false,
-  },
-  {
-    id: '5',
-    taskId: '105',
-    taskTitle: 'House painting',
-    userId: '102',
-    userName: 'Vikram Reddy',
-    userAvatar: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80',
-    rating: 5,
-    comment: "Excellent work! Very professional and completed the job ahead of schedule.",
-    date: '2023-06-02',
-    userReview: false,
-  },
+  { id: '4', taskId: '104', taskTitle: 'Garden maintenance', userId: '101', userName: 'Ananya Sharma', userAvatar: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80', rating: 4, comment: "Good service, but could improve on timeliness.", date: '2023-06-15', userReview: false, },
+  { id: '5', taskId: '105', taskTitle: 'House painting', userId: '102', userName: 'Vikram Reddy', userAvatar: 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80', rating: 5, comment: "Excellent work! Very professional and completed the job ahead of schedule.", date: '2023-06-02', userReview: false, },
 ];
 
 export default function ReviewsScreen() {
+  const { colors } = useTheme();
+  const navigation = useNavigation();
+  const styles = dynamicStyles(colors, originalTheme);
+
   const [activeTab, setActiveTab] = useState('given');
-  const [reviews, setReviews] = useState<ReviewGiven[]>(mockReviews);
-  const [reviewsReceived, setReviewsReceived] = useState<ReviewReceived[]>(mockReviewsReceived);
+  // Using mock data for now
+  const currentReviews = activeTab === 'given' ? mockReviews : mockReviewsReceived;
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerStyle: { backgroundColor: colors.background },
+      headerTitleStyle: { color: colors.text },
+      headerLeft: () => (
+        <TouchableOpacity 
+          style={styles.headerButton} // Layout only
+          onPress={() => router.back()}
+        >
+          <ChevronLeft size={24} color={colors.text} />
+        </TouchableOpacity>
+      ),
+    });
+  }, [navigation, colors]);
 
   const renderStars = (rating: number) => {
     const stars = [];
     const fullStars = Math.floor(rating);
-    const halfStar = rating % 1 >= 0.5;
+    const halfStar = rating % 1 >= 0.25; // Adjusted for half star visibility
     
     for (let i = 0; i < 5; i++) {
       if (i < fullStars) {
-        stars.push(
-          <Star key={i} size={16} color={theme.colors.light.warning} fill={theme.colors.light.warning} />
-        );
+        stars.push(<Star key={i} size={16} color={colors.warning} fill={colors.warning} />);
       } else if (i === fullStars && halfStar) {
-        stars.push(
-          <Star key={i} size={16} color={theme.colors.light.warning} fill={theme.colors.light.warning} />
-        );
+        // Using full star for half for now, can be replaced with a half-star icon if available
+        stars.push(<Star key={i} size={16} color={colors.warning} fill={colors.warning} />); 
       } else {
-        stars.push(
-          <Star key={i} size={16} color={theme.colors.light.inactive} />
-        );
+        stars.push(<Star key={i} size={16} color={colors.inactive} />);
       }
     }
-    
     return stars;
   };
 
   const calculateAverageRating = (reviewsList: ReviewGiven[] | ReviewReceived[]) => {
-    if (reviewsList.length === 0) return 0;
-    
+    if (reviewsList.length === 0) return "0.0"; // Return string for consistency
     const sum = reviewsList.reduce((acc, review) => acc + review.rating, 0);
     return (sum / reviewsList.length).toFixed(1);
   };
@@ -147,22 +103,21 @@ export default function ReviewsScreen() {
   type ReviewItem = ReviewGiven | ReviewReceived;
 
   const renderReviewItem = ({ item }: { item: ReviewItem }) => {
-    // Determine if this is a review given or received
     const isReviewGiven = 'taskerName' in item;
     
     return (
       <View style={styles.reviewCard}>
         <View style={styles.reviewHeader}>
           <Image
-            source={{ uri: isReviewGiven ? item.taskerAvatar : item.userAvatar }}
+            source={{ uri: isReviewGiven ? (item as ReviewGiven).taskerAvatar : (item as ReviewReceived).userAvatar }}
             style={styles.avatar}
           />
           <View style={styles.reviewHeaderInfo}>
             <Text style={styles.reviewerName}>
-              {isReviewGiven ? item.taskerName : item.userName}
+              {isReviewGiven ? (item as ReviewGiven).taskerName : (item as ReviewReceived).userName}
             </Text>
             <Text style={styles.taskTitle}>{item.taskTitle}</Text>
-            <Text style={styles.reviewDate}>{item.date}</Text>
+            <Text style={styles.reviewDate}>{new Date(item.date).toLocaleDateString()}</Text>
           </View>
         </View>
         
@@ -175,11 +130,11 @@ export default function ReviewsScreen() {
         
         <View style={styles.reviewActions}>
           <TouchableOpacity style={styles.reviewActionButton}>
-            <ThumbsUp size={16} color={theme.colors.light.subtext} />
+            <ThumbsUp size={16} color={colors.subtext} />
             <Text style={styles.reviewActionText}>Helpful</Text>
           </TouchableOpacity>
           <TouchableOpacity style={styles.reviewActionButton}>
-            <ThumbsDown size={16} color={theme.colors.light.subtext} />
+            <ThumbsDown size={16} color={colors.subtext} />
             <Text style={styles.reviewActionText}>Not Helpful</Text>
           </TouchableOpacity>
         </View>
@@ -187,91 +142,55 @@ export default function ReviewsScreen() {
     );
   };
 
+  const averageRatingValue = parseFloat(calculateAverageRating(currentReviews));
+
   return (
     <>
-      <Stack.Screen 
-        options={{
-          title: 'Reviews & Ratings',
-          headerLeft: () => (
-            <TouchableOpacity 
-              style={styles.headerButton}
-              onPress={() => router.back()}
-            >
-              <ChevronLeft size={24} color={theme.colors.light.text} />
-            </TouchableOpacity>
-          ),
-        }} 
-      />
+      {/* Stack.Screen options are now set dynamically via useEffect */}
       <SafeAreaView style={styles.container} edges={['bottom']}>
         <View style={styles.statsContainer}>
           <View style={styles.statItem}>
-            <Text style={styles.statValue}>
-              {activeTab === 'given' 
-                ? calculateAverageRating(reviews) 
-                : calculateAverageRating(reviewsReceived)}
-            </Text>
+            <Text style={styles.statValue}>{calculateAverageRating(currentReviews)}</Text>
             <View style={styles.statStars}>
-              {renderStars(parseFloat(
-                activeTab === 'given' 
-                  ? calculateAverageRating(reviews) 
-                  : calculateAverageRating(reviewsReceived)
-              ))}
+              {renderStars(averageRatingValue)}
             </View>
             <Text style={styles.statLabel}>Average Rating</Text>
           </View>
           <View style={styles.statDivider} />
           <View style={styles.statItem}>
-            <Text style={styles.statValue}>
-              {activeTab === 'given' ? reviews.length : reviewsReceived.length}
-            </Text>
+            <Text style={styles.statValue}>{currentReviews.length}</Text>
             <Text style={styles.statLabel}>Total Reviews</Text>
           </View>
         </View>
 
         <View style={styles.tabContainer}>
           <TouchableOpacity 
-            style={[
-              styles.tabButton,
-              activeTab === 'given' && styles.activeTabButton
-            ]}
+            style={[styles.tabButton, activeTab === 'given' && styles.activeTabButton]}
             onPress={() => setActiveTab('given')}
           >
-            <Text 
-              style={[
-                styles.tabButtonText,
-                activeTab === 'given' && styles.activeTabButtonText
-              ]}
-            >
+            <Text style={[styles.tabButtonText, activeTab === 'given' && styles.activeTabButtonText]}>
               Reviews Given
             </Text>
           </TouchableOpacity>
           <TouchableOpacity 
-            style={[
-              styles.tabButton,
-              activeTab === 'received' && styles.activeTabButton
-            ]}
+            style={[styles.tabButton, activeTab === 'received' && styles.activeTabButton]}
             onPress={() => setActiveTab('received')}
           >
-            <Text 
-              style={[
-                styles.tabButtonText,
-                activeTab === 'received' && styles.activeTabButtonText
-              ]}
-            >
+            <Text style={[styles.tabButtonText, activeTab === 'received' && styles.activeTabButtonText]}>
               Reviews Received
             </Text>
           </TouchableOpacity>
         </View>
 
         <FlatList
-          data={activeTab === 'given' ? reviews : reviewsReceived}
+          data={currentReviews}
           keyExtractor={(item) => item.id}
           renderItem={renderReviewItem}
           contentContainerStyle={styles.reviewsList}
           showsVerticalScrollIndicator={false}
           ListEmptyComponent={
             <View style={styles.emptyContainer}>
-              <Star size={60} color={theme.colors.light.subtext} />
+              <Star size={60} color={colors.subtext} />
               <Text style={styles.emptyTitle}>No Reviews Yet</Text>
               <Text style={styles.emptyText}>
                 {activeTab === 'given'
@@ -287,160 +206,169 @@ export default function ReviewsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: theme.colors.light.background,
-  },
-  headerButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  statsContainer: {
-    flexDirection: 'row',
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    marginHorizontal: theme.spacing.l,
-    marginTop: theme.spacing.l,
-    padding: theme.spacing.l,
-  },
-  statItem: {
-    flex: 1,
-    alignItems: 'center',
-  },
-  statValue: {
-    ...theme.typography.h2,
-    marginBottom: theme.spacing.xs,
-  },
-  statStars: {
-    flexDirection: 'row',
-    marginBottom: theme.spacing.xs,
-  },
-  statLabel: {
-    ...theme.typography.caption,
-    color: theme.colors.light.subtext,
-  },
-  statDivider: {
-    width: 1,
-    height: '80%',
-    backgroundColor: theme.colors.light.border,
-    alignSelf: 'center',
-  },
-  tabContainer: {
-    flexDirection: 'row',
-    marginHorizontal: theme.spacing.l,
-    marginTop: theme.spacing.l,
-    marginBottom: theme.spacing.m,
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    padding: theme.spacing.xs,
-  },
-  tabButton: {
-    flex: 1,
-    paddingVertical: theme.spacing.s,
-    alignItems: 'center',
-    borderRadius: theme.radius.m,
-  },
-  activeTabButton: {
-    backgroundColor: theme.colors.light.primary,
-  },
-  tabButtonText: {
-    ...theme.typography.bodySmall,
-    fontWeight: '600',
-    color: theme.colors.light.text,
-  },
-  activeTabButtonText: {
-    color: theme.colors.common.white,
-  },
-  reviewsList: {
-    padding: theme.spacing.l,
-    paddingBottom: theme.spacing.xxl,
-  },
-  reviewCard: {
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    padding: theme.spacing.l,
-    marginBottom: theme.spacing.m,
-    shadowColor: theme.colors.common.black,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  reviewHeader: {
-    flexDirection: 'row',
-    marginBottom: theme.spacing.m,
-  },
-  avatar: {
-    width: 50,
-    height: 50,
-    borderRadius: 25,
-    marginRight: theme.spacing.m,
-  },
-  reviewHeaderInfo: {
-    flex: 1,
-  },
-  reviewerName: {
-    ...theme.typography.body,
-    fontWeight: '600',
-    marginBottom: 2,
-  },
-  taskTitle: {
-    ...theme.typography.bodySmall,
-    marginBottom: 2,
-  },
-  reviewDate: {
-    ...theme.typography.caption,
-    color: theme.colors.light.subtext,
-  },
-  ratingContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: theme.spacing.m,
-  },
-  ratingText: {
-    ...theme.typography.bodySmall,
-    fontWeight: '600',
-    marginLeft: theme.spacing.s,
-  },
-  reviewComment: {
-    ...theme.typography.body,
-    lineHeight: 22,
-    marginBottom: theme.spacing.m,
-  },
-  reviewActions: {
-    flexDirection: 'row',
-    borderTopWidth: 1,
-    borderTopColor: theme.colors.light.border,
-    paddingTop: theme.spacing.m,
-  },
-  reviewActionButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginRight: theme.spacing.l,
-  },
-  reviewActionText: {
-    ...theme.typography.caption,
-    color: theme.colors.light.subtext,
-    marginLeft: theme.spacing.xs,
-  },
-  emptyContainer: {
-    alignItems: 'center',
-    padding: theme.spacing.xl,
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-  },
-  emptyTitle: {
-    ...theme.typography.h3,
-    marginTop: theme.spacing.m,
-    marginBottom: theme.spacing.s,
-  },
-  emptyText: {
-    ...theme.typography.body,
-    color: theme.colors.light.subtext,
-    textAlign: 'center',
-  },
-});
+const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentTheme: typeof originalTheme) => 
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    headerButton: { // Layout only
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    statsContainer: {
+      flexDirection: 'row',
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+      marginHorizontal: currentTheme.spacing.l,
+      marginTop: currentTheme.spacing.l,
+      padding: currentTheme.spacing.l,
+    },
+    statItem: {
+      flex: 1,
+      alignItems: 'center',
+    },
+    statValue: {
+      ...currentTheme.typography.h2,
+      color: colors.text, // Added
+      marginBottom: currentTheme.spacing.xs,
+    },
+    statStars: {
+      flexDirection: 'row',
+      marginBottom: currentTheme.spacing.xs,
+    },
+    statLabel: {
+      ...currentTheme.typography.caption,
+      color: colors.subtext,
+    },
+    statDivider: {
+      width: 1,
+      height: '80%',
+      backgroundColor: colors.border,
+      alignSelf: 'center',
+    },
+    tabContainer: {
+      flexDirection: 'row',
+      marginHorizontal: currentTheme.spacing.l,
+      marginTop: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.m,
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+      padding: currentTheme.spacing.xs,
+    },
+    tabButton: {
+      flex: 1,
+      paddingVertical: currentTheme.spacing.s,
+      alignItems: 'center',
+      borderRadius: currentTheme.radius.m,
+    },
+    activeTabButton: {
+      backgroundColor: colors.primary,
+    },
+    tabButtonText: {
+      ...currentTheme.typography.bodySmall,
+      fontWeight: '600',
+      color: colors.text,
+    },
+    activeTabButtonText: {
+      color: currentTheme.colors.common.white,
+    },
+    reviewsList: {
+      paddingHorizontal: currentTheme.spacing.l, // Changed from padding
+      paddingBottom: currentTheme.spacing.xxl,
+    },
+    reviewCard: {
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+      padding: currentTheme.spacing.l,
+      marginBottom: currentTheme.spacing.m,
+      shadowColor: currentTheme.colors.common.black,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.05,
+      shadowRadius: 8,
+      elevation: 2,
+    },
+    reviewHeader: {
+      flexDirection: 'row',
+      marginBottom: currentTheme.spacing.m,
+    },
+    avatar: {
+      width: 50,
+      height: 50,
+      borderRadius: 25,
+      marginRight: currentTheme.spacing.m,
+    },
+    reviewHeaderInfo: {
+      flex: 1,
+    },
+    reviewerName: {
+      ...currentTheme.typography.body,
+      fontWeight: '600',
+      color: colors.text, // Added
+      marginBottom: 2,
+    },
+    taskTitle: {
+      ...currentTheme.typography.bodySmall,
+      color: colors.text, // Added
+      marginBottom: 2,
+    },
+    reviewDate: {
+      ...currentTheme.typography.caption,
+      color: colors.subtext,
+    },
+    ratingContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginBottom: currentTheme.spacing.m,
+    },
+    ratingText: {
+      ...currentTheme.typography.bodySmall,
+      fontWeight: '600',
+      color: colors.text, // Added
+      marginLeft: currentTheme.spacing.s,
+    },
+    reviewComment: {
+      ...currentTheme.typography.body,
+      lineHeight: 22,
+      color: colors.text, // Added
+      marginBottom: currentTheme.spacing.m,
+    },
+    reviewActions: {
+      flexDirection: 'row',
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+      paddingTop: currentTheme.spacing.m,
+    },
+    reviewActionButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginRight: currentTheme.spacing.l,
+    },
+    reviewActionText: {
+      ...currentTheme.typography.caption,
+      color: colors.subtext,
+      marginLeft: currentTheme.spacing.xs,
+    },
+    emptyContainer: {
+      alignItems: 'center',
+      padding: currentTheme.spacing.xl,
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+    },
+    emptyTitle: {
+      ...currentTheme.typography.h3,
+      color: colors.text, // Added
+      marginTop: currentTheme.spacing.m,
+      marginBottom: currentTheme.spacing.s,
+    },
+    emptyText: {
+      ...currentTheme.typography.body,
+      color: colors.subtext,
+      textAlign: 'center',
+    },
+  });
+
+export default ReviewsScreen;

--- a/Handlr/app/profile/transactions.tsx
+++ b/Handlr/app/profile/transactions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react'; // Added useEffect
 import { 
   View, 
   Text, 
@@ -7,7 +7,7 @@ import {
   TouchableOpacity,
   Image
 } from 'react-native';
-import { router, Stack } from 'expo-router';
+import { router, Stack, useNavigation } from 'expo-router'; // Added useNavigation
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { 
   ChevronLeft, 
@@ -19,67 +19,57 @@ import {
   CreditCard,
   Wallet
 } from 'lucide-react-native';
-import theme from '@/constants/theme';
+import originalTheme from '@/constants/theme'; // Renamed
+import { useTheme } from '../../../context/ThemeContext'; // Added
 
-// Mock transactions data
+// Mock transactions data (data remains the same)
 const mockTransactions = [
-  {
-    id: '1',
-    type: 'payment',
-    amount: 1500,
-    taskId: '101',
-    taskTitle: 'Deep cleaning of 2BHK apartment',
-    taskerId: '1',
-    taskerName: 'Rajesh Kumar',
-    taskerAvatar: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80',
-    date: '2023-06-10',
-    status: 'completed',
-    paymentMethod: 'HDFC Credit Card',
-  },
-  {
-    id: '2',
-    type: 'payment',
-    amount: 500,
-    taskId: '102',
-    taskTitle: 'Fix leaking bathroom tap',
-    taskerId: '2',
-    taskerName: 'Priya Singh',
-    taskerAvatar: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80',
-    date: '2023-06-05',
-    status: 'completed',
-    paymentMethod: 'Google Pay',
-  },
-  {
-    id: '3',
-    type: 'payment',
-    amount: 700,
-    taskId: '103',
-    taskTitle: 'Install new ceiling fan',
-    taskerId: '3',
-    taskerName: 'Amit Patel',
-    taskerAvatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80',
-    date: '2023-05-28',
-    status: 'completed',
-    paymentMethod: 'Paytm Wallet',
-  },
-  {
-    id: '4',
-    type: 'refund',
-    amount: 300,
-    taskId: '104',
-    taskTitle: 'Garden maintenance',
-    taskerId: '1',
-    taskerName: 'Rajesh Kumar',
-    taskerAvatar: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80',
-    date: '2023-05-20',
-    status: 'completed',
-    paymentMethod: 'HDFC Credit Card',
-  },
+  { id: '1', type: 'payment', amount: 1500, taskId: '101', taskTitle: 'Deep cleaning of 2BHK apartment', taskerId: '1', taskerName: 'Rajesh Kumar', taskerAvatar: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80', date: '2023-06-10', status: 'completed', paymentMethod: 'HDFC Credit Card', },
+  { id: '2', type: 'payment', amount: 500, taskId: '102', taskTitle: 'Fix leaking bathroom tap', taskerId: '2', taskerName: 'Priya Singh', taskerAvatar: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80', date: '2023-06-05', status: 'completed', paymentMethod: 'Google Pay', },
+  { id: '3', type: 'payment', amount: 700, taskId: '103', taskTitle: 'Install new ceiling fan', taskerId: '3', taskerName: 'Amit Patel', taskerAvatar: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80', date: '2023-05-28', status: 'completed', paymentMethod: 'Paytm Wallet', },
+  { id: '4', type: 'refund', amount: 300, taskId: '104', taskTitle: 'Garden maintenance', taskerId: '1', taskerName: 'Rajesh Kumar', taskerAvatar: 'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?ixlib=rb-1.2.1&auto=format&fit=crop&w=200&q=80', date: '2023-05-20', status: 'completed', paymentMethod: 'HDFC Credit Card', },
 ];
 
+type Transaction = typeof mockTransactions[0];
+
 export default function TransactionsScreen() {
+  const { colors } = useTheme();
+  const navigation = useNavigation();
+  const styles = dynamicStyles(colors, originalTheme);
+
   const [transactions, setTransactions] = useState(mockTransactions);
   const [filterActive, setFilterActive] = useState(false);
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerStyle: { backgroundColor: colors.background },
+      headerTitleStyle: { color: colors.text },
+      headerLeft: () => (
+        <TouchableOpacity 
+          style={styles.headerButton} // Layout only
+          onPress={() => router.back()}
+        >
+          <ChevronLeft size={24} color={colors.text} />
+        </TouchableOpacity>
+      ),
+      headerRight: () => (
+        <View style={styles.headerActions}>
+          <TouchableOpacity style={styles.headerButton} onPress={() => { /* Date picker logic */ }}>
+            <Calendar size={20} color={colors.text} />
+          </TouchableOpacity>
+          <TouchableOpacity 
+            style={[styles.headerButton, filterActive && styles.headerButtonActive]}
+            onPress={() => setFilterActive(!filterActive)}
+          >
+            <Filter size={20} color={filterActive ? colors.primary : colors.text} />
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.headerButton} onPress={() => { /* Download logic */ }}>
+            <Download size={20} color={colors.text} />
+          </TouchableOpacity>
+        </View>
+      ),
+    });
+  }, [navigation, colors, filterActive, styles.headerButton, styles.headerButtonActive, styles.headerActions]); // Added dependencies
 
   const totalSpent = transactions
     .filter(t => t.type === 'payment')
@@ -91,16 +81,16 @@ export default function TransactionsScreen() {
 
   const getPaymentMethodIcon = (method: string) => {
     if (method.includes('Credit') || method.includes('Debit')) {
-      return <CreditCard size={16} color={theme.colors.light.subtext} />;
+      return <CreditCard size={16} color={colors.subtext} />;
     } else {
-      return <Wallet size={16} color={theme.colors.light.subtext} />;
+      return <Wallet size={16} color={colors.subtext} />;
     }
   };
 
-  const renderTransactionItem = ({ item }: { item: typeof mockTransactions[0] }) => (
+  const renderTransactionItem = ({ item }: { item: Transaction }) => (
     <TouchableOpacity 
       style={styles.transactionCard}
-      onPress={() => router.push(`/task/${item.taskId}`)}
+      onPress={() => router.push(`/task/${item.taskId}`)} // Assuming task details page exists
       activeOpacity={0.7}
     >
       <View style={styles.transactionHeader}>
@@ -112,7 +102,7 @@ export default function TransactionsScreen() {
           <View style={styles.transactionInfo}>
             <Text style={styles.taskTitle} numberOfLines={1}>{item.taskTitle}</Text>
             <Text style={styles.taskerName}>{item.taskerName}</Text>
-            <Text style={styles.transactionDate}>{item.date}</Text>
+            <Text style={styles.transactionDate}>{new Date(item.date).toLocaleDateString()}</Text>
           </View>
         </View>
         <View style={styles.transactionRight}>
@@ -149,8 +139,8 @@ export default function TransactionsScreen() {
           ]}
         >
           {item.type === 'refund' 
-            ? <ArrowDown size={12} color={theme.colors.light.success} /> 
-            : <ArrowUp size={12} color={theme.colors.light.primary} />
+            ? <ArrowDown size={12} color={colors.success} /> 
+            : <ArrowUp size={12} color={colors.primary} />
           }
           <Text 
             style={[
@@ -167,44 +157,7 @@ export default function TransactionsScreen() {
 
   return (
     <>
-      <Stack.Screen 
-        options={{
-          title: 'Transaction History',
-          headerLeft: () => (
-            <TouchableOpacity 
-              style={styles.headerButton}
-              onPress={() => router.back()}
-            >
-              <ChevronLeft size={24} color={theme.colors.light.text} />
-            </TouchableOpacity>
-          ),
-          headerRight: () => (
-            <View style={styles.headerActions}>
-              <TouchableOpacity 
-                style={styles.headerButton}
-                onPress={() => {}}
-              >
-                <Calendar size={20} color={theme.colors.light.text} />
-              </TouchableOpacity>
-              <TouchableOpacity 
-                style={[
-                  styles.headerButton,
-                  filterActive && styles.headerButtonActive
-                ]}
-                onPress={() => setFilterActive(!filterActive)}
-              >
-                <Filter size={20} color={filterActive ? theme.colors.light.primary : theme.colors.light.text} />
-              </TouchableOpacity>
-              <TouchableOpacity 
-                style={styles.headerButton}
-                onPress={() => {}}
-              >
-                <Download size={20} color={theme.colors.light.text} />
-              </TouchableOpacity>
-            </View>
-          ),
-        }} 
-      />
+      {/* Stack.Screen options are now set dynamically via useEffect */}
       <SafeAreaView style={styles.container} edges={['bottom']}>
         <View style={styles.summaryContainer}>
           <View style={styles.summaryItem}>
@@ -226,7 +179,7 @@ export default function TransactionsScreen() {
           showsVerticalScrollIndicator={false}
           ListEmptyComponent={
             <View style={styles.emptyContainer}>
-              <CreditCard size={60} color={theme.colors.light.subtext} />
+              <CreditCard size={60} color={colors.subtext} />
               <Text style={styles.emptyTitle}>No Transactions</Text>
               <Text style={styles.emptyText}>
                 You haven't made any transactions yet.
@@ -239,187 +192,194 @@ export default function TransactionsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: theme.colors.light.background,
-  },
-  headerButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    justifyContent: 'center',
-    alignItems: 'center',
-    marginHorizontal: 4,
-  },
-  headerButtonActive: {
-    backgroundColor: theme.colors.light.highlight,
-  },
-  headerActions: {
-    flexDirection: 'row',
-  },
-  summaryContainer: {
-    flexDirection: 'row',
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    marginHorizontal: theme.spacing.l,
-    marginTop: theme.spacing.l,
-    padding: theme.spacing.l,
-  },
-  summaryItem: {
-    flex: 1,
-    alignItems: 'center',
-  },
-  summaryLabel: {
-    ...theme.typography.bodySmall,
-    color: theme.colors.light.subtext,
-    marginBottom: theme.spacing.xs,
-  },
-  summaryValue: {
-    ...theme.typography.h3,
-    color: theme.colors.light.primary,
-  },
-  refundValue: {
-    color: theme.colors.light.success,
-  },
-  summaryDivider: {
-    width: 1,
-    height: '80%',
-    backgroundColor: theme.colors.light.border,
-    alignSelf: 'center',
-  },
-  transactionsList: {
-    padding: theme.spacing.l,
-    paddingBottom: theme.spacing.xxl,
-  },
-  transactionCard: {
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    padding: theme.spacing.m,
-    marginBottom: theme.spacing.m,
-    shadowColor: theme.colors.common.black,
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.05,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  transactionHeader: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: theme.spacing.m,
-  },
-  transactionLeft: {
-    flexDirection: 'row',
-    flex: 1,
-  },
-  taskerAvatar: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
-    marginRight: theme.spacing.m,
-  },
-  transactionInfo: {
-    flex: 1,
-  },
-  taskTitle: {
-    ...theme.typography.body,
-    fontWeight: '600',
-    marginBottom: 2,
-  },
-  taskerName: {
-    ...theme.typography.bodySmall,
-    marginBottom: 2,
-  },
-  transactionDate: {
-    ...theme.typography.caption,
-    color: theme.colors.light.subtext,
-  },
-  transactionRight: {
-    alignItems: 'flex-end',
-  },
-  transactionAmount: {
-    ...theme.typography.body,
-    fontWeight: '600',
-    marginBottom: 4,
-  },
-  paymentAmount: {
-    color: theme.colors.light.primary,
-  },
-  refundAmount: {
-    color: theme.colors.light.success,
-  },
-  statusBadge: {
-    paddingHorizontal: theme.spacing.s,
-    paddingVertical: 2,
-    borderRadius: theme.radius.s,
-  },
-  completedBadge: {
-    backgroundColor: theme.colors.light.success + '20',
-  },
-  pendingBadge: {
-    backgroundColor: theme.colors.light.warning + '20',
-  },
-  statusText: {
-    ...theme.typography.caption,
-    fontWeight: '600',
-    color: theme.colors.light.text,
-  },
-  transactionFooter: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    borderTopWidth: 1,
-    borderTopColor: theme.colors.light.border,
-    paddingTop: theme.spacing.m,
-  },
-  paymentMethodContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  paymentMethodText: {
-    ...theme.typography.caption,
-    color: theme.colors.light.subtext,
-    marginLeft: theme.spacing.xs,
-  },
-  transactionTypeBadge: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: theme.spacing.s,
-    paddingVertical: 4,
-    borderRadius: theme.radius.s,
-  },
-  paymentBadge: {
-    backgroundColor: theme.colors.light.primary + '20',
-  },
-  refundBadge: {
-    backgroundColor: theme.colors.light.success + '20',
-  },
-  transactionTypeText: {
-    ...theme.typography.caption,
-    fontWeight: '600',
-    marginLeft: 4,
-  },
-  paymentText: {
-    color: theme.colors.light.primary,
-  },
-  refundText: {
-    color: theme.colors.light.success,
-  },
-  emptyContainer: {
-    alignItems: 'center',
-    padding: theme.spacing.xl,
-    backgroundColor: theme.colors.light.card,
-    borderRadius: theme.radius.l,
-    marginTop: theme.spacing.l,
-  },
-  emptyTitle: {
-    ...theme.typography.h3,
-    marginTop: theme.spacing.m,
-    marginBottom: theme.spacing.s,
-  },
-  emptyText: {
-    ...theme.typography.body,
-    color: theme.colors.light.subtext,
-    textAlign: 'center',
-  },
-});
+const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentTheme: typeof originalTheme) => 
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    headerButton: { // Layout only
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      justifyContent: 'center',
+      alignItems: 'center',
+      marginHorizontal: 4,
+    },
+    headerButtonActive: {
+      backgroundColor: colors.highlight,
+    },
+    headerActions: {
+      flexDirection: 'row',
+    },
+    summaryContainer: {
+      flexDirection: 'row',
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+      marginHorizontal: currentTheme.spacing.l,
+      marginTop: currentTheme.spacing.l,
+      padding: currentTheme.spacing.l,
+    },
+    summaryItem: {
+      flex: 1,
+      alignItems: 'center',
+    },
+    summaryLabel: {
+      ...currentTheme.typography.bodySmall,
+      color: colors.subtext,
+      marginBottom: currentTheme.spacing.xs,
+    },
+    summaryValue: {
+      ...currentTheme.typography.h3,
+      color: colors.primary,
+    },
+    refundValue: {
+      color: colors.success,
+    },
+    summaryDivider: {
+      width: 1,
+      height: '80%',
+      backgroundColor: colors.border,
+      alignSelf: 'center',
+    },
+    transactionsList: {
+      padding: currentTheme.spacing.l,
+      paddingBottom: currentTheme.spacing.xxl,
+    },
+    transactionCard: {
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+      padding: currentTheme.spacing.m,
+      marginBottom: currentTheme.spacing.m,
+      shadowColor: currentTheme.colors.common.black,
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.05,
+      shadowRadius: 8,
+      elevation: 2,
+    },
+    transactionHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginBottom: currentTheme.spacing.m,
+    },
+    transactionLeft: {
+      flexDirection: 'row',
+      flex: 1, // Allow this to take space
+      marginRight: currentTheme.spacing.s, // Add some space before amount
+    },
+    taskerAvatar: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      marginRight: currentTheme.spacing.m,
+    },
+    transactionInfo: {
+      flex: 1, // Allow text to shrink if needed
+    },
+    taskTitle: {
+      ...currentTheme.typography.body,
+      fontWeight: '600',
+      color: colors.text, // Added
+      marginBottom: 2,
+    },
+    taskerName: {
+      ...currentTheme.typography.bodySmall,
+      color: colors.text, // Added
+      marginBottom: 2,
+    },
+    transactionDate: {
+      ...currentTheme.typography.caption,
+      color: colors.subtext,
+    },
+    transactionRight: {
+      alignItems: 'flex-end',
+    },
+    transactionAmount: {
+      ...currentTheme.typography.body,
+      fontWeight: '600',
+      marginBottom: 4,
+    },
+    paymentAmount: {
+      color: colors.primary,
+    },
+    refundAmount: {
+      color: colors.success,
+    },
+    statusBadge: {
+      paddingHorizontal: currentTheme.spacing.s,
+      paddingVertical: 2,
+      borderRadius: currentTheme.radius.s,
+    },
+    completedBadge: {
+      backgroundColor: colors.success + '20',
+    },
+    pendingBadge: { // Example if you have pending status
+      backgroundColor: colors.warning + '20',
+    },
+    statusText: {
+      ...currentTheme.typography.caption,
+      fontWeight: '600',
+      color: colors.text, // Updated (text on badge should be themed)
+    },
+    transactionFooter: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      borderTopWidth: 1,
+      borderTopColor: colors.border,
+      paddingTop: currentTheme.spacing.m,
+    },
+    paymentMethodContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    paymentMethodText: {
+      ...currentTheme.typography.caption,
+      color: colors.subtext,
+      marginLeft: currentTheme.spacing.xs,
+    },
+    transactionTypeBadge: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: currentTheme.spacing.s,
+      paddingVertical: 4,
+      borderRadius: currentTheme.radius.s,
+    },
+    paymentBadge: {
+      backgroundColor: colors.primary + '20',
+    },
+    refundBadge: {
+      backgroundColor: colors.success + '20',
+    },
+    transactionTypeText: {
+      ...currentTheme.typography.caption,
+      fontWeight: '600',
+      marginLeft: 4,
+    },
+    paymentText: {
+      color: colors.primary,
+    },
+    refundText: {
+      color: colors.success,
+    },
+    emptyContainer: {
+      alignItems: 'center',
+      padding: currentTheme.spacing.xl,
+      backgroundColor: colors.card,
+      borderRadius: currentTheme.radius.l,
+      marginTop: currentTheme.spacing.l, // Added to separate from summary
+    },
+    emptyTitle: {
+      ...currentTheme.typography.h3,
+      color: colors.text, // Added
+      marginTop: currentTheme.spacing.m,
+      marginBottom: currentTheme.spacing.s,
+    },
+    emptyText: {
+      ...currentTheme.typography.body,
+      color: colors.subtext,
+      textAlign: 'center',
+    },
+  });
+
+export default TransactionsScreen;

--- a/Handlr/components/Button.tsx
+++ b/Handlr/components/Button.tsx
@@ -118,7 +118,7 @@ const Button: React.FC<ButtonProps> = ({
         baseStyle.color = colors.primary; // Updated
         break;
       default: // primary, secondary
-        baseStyle.color = colors.white; // Updated (assuming colors.white is from common)
+        baseStyle.color = originalTheme.colors.common.white; 
     }
 
     return baseStyle;
@@ -136,8 +136,8 @@ const Button: React.FC<ButtonProps> = ({
         <ActivityIndicator 
           size="small" 
           color={variant === 'outline' || variant === 'ghost' 
-            ? colors.primary // Updated
-            : colors.white} // Updated
+            ? colors.primary 
+            : originalTheme.colors.common.white} 
         />
       ) : (
         <>

--- a/Handlr/components/CategoryCard.tsx
+++ b/Handlr/components/CategoryCard.tsx
@@ -60,17 +60,17 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
     >
       {getCategoryIcon(
         category.icon,
-        // Use colors from context for selected icon color (white)
+        // Use common.white for selected icon color
         // Unselected icon color remains category.color (data-driven)
-        selected ? colors.white : category.color, 
+        selected ? originalTheme.colors.common.white : category.color, 
         24
       )}
       <Text
         style={[
           styles.name,
-          // Use colors from context for text color when unselected
-          // Selected text color remains white (or could be a contrast color to category.color if needed)
-          { color: selected ? colors.white : colors.text }, 
+          // Use common.white for selected text color
+          // Unselected text color uses theme-dependent colors.text
+          { color: selected ? originalTheme.colors.common.white : colors.text }, 
         ]}
         numberOfLines={1}
       >

--- a/Handlr/components/TaskCard.tsx
+++ b/Handlr/components/TaskCard.tsx
@@ -103,7 +103,7 @@ const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentThe
       borderRadius: currentTheme.radius.l,
       padding: currentTheme.spacing.m,
       marginBottom: currentTheme.spacing.m,
-      shadowColor: colors.black, // Updated from common.black
+      shadowColor: currentTheme.colors.common.black, // Changed to common.black
       shadowOffset: { width: 0, height: 2 },
       shadowOpacity: 0.05,
       shadowRadius: 8,
@@ -130,7 +130,7 @@ const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentThe
       borderRadius: currentTheme.radius.s,
     },
     statusText: {
-      color: colors.white, // Updated from common.white
+      color: currentTheme.colors.common.white, // Changed to common.white
       fontSize: 10,
       fontWeight: '600',
     },

--- a/Handlr/components/TaskerCard.tsx
+++ b/Handlr/components/TaskerCard.tsx
@@ -73,7 +73,7 @@ const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentThe
       borderRadius: currentTheme.radius.l,
       padding: currentTheme.spacing.m,
       marginBottom: currentTheme.spacing.m,
-      shadowColor: colors.black, // Updated
+      shadowColor: currentTheme.colors.common.black, // Changed to common.black
       shadowOffset: { width: 0, height: 2 },
       shadowOpacity: 0.05,
       shadowRadius: 8,
@@ -109,7 +109,7 @@ const dynamicStyles = (colors: ReturnType<typeof useTheme>['colors'], currentThe
       borderRadius: currentTheme.radius.s,
     },
     verifiedText: {
-      color: colors.white, // Updated (assuming white is contrast for success)
+      color: currentTheme.colors.common.white, // Changed to common.white
       fontSize: 10,
       fontWeight: '600',
     },


### PR DESCRIPTION
I've implemented a comprehensive dark mode feature across the application. This includes:
- Added a dark color palette and a ThemeContext for managing theme state (light/dark/system) with AsyncStorage persistence.
- Refactored all major components, tab screens (Home, Explore, Chats, Profile), and profile sub-screens (Edit, Payment Methods, Personal Info, Reviews, Transactions) to be theme-aware using dynamic styles. Headers for sub-screens are also themed.
- Fixed a runtime error on the Profile screen caused by incorrect color references in dark mode by ensuring common colors (like white/black on fixed backgrounds) are correctly sourced.
- Added a new "Categories" screen accessible via a new tab in the bottom navigation bar. The screen includes a search bar, filter buttons, and a grid display of categories with icons, all styled according to the theme.
- Standardized theming for the tab bar and its icons.

Further testing is recommended to catch any remaining visual inconsistencies or minor bugs.